### PR TITLE
framework for configuring chat commands and permissions

### DIFF
--- a/SubathonManager.Core/Events/TwitchEvents.cs
+++ b/SubathonManager.Core/Events/TwitchEvents.cs
@@ -3,9 +3,15 @@
 public static class TwitchEvents
 {
     public static event Action? TwitchConnected;
+    public static event Action? CommandSettingsUpdated; // TODO can be reused by YT or copied? or split out?
 
     public static void RaiseTwitchConnected()
     {
         TwitchConnected?.Invoke();
+    }
+
+    public static void RaiseCommandSettingsUpdated()
+    {
+        CommandSettingsUpdated?.Invoke();
     }
 }

--- a/SubathonManager.UI/Views/SettingsView.Settings.cs
+++ b/SubathonManager.UI/Views/SettingsView.Settings.cs
@@ -3,12 +3,132 @@ using System.Windows.Controls;
 using System.Diagnostics;
 using SubathonManager.Core;
 using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
 
 namespace SubathonManager.UI.Views
 {
     public partial class SettingsView
     {
 
+        private void InitCommandSettings()
+        {
+            foreach (SubathonCommandType commandType in Enum.GetValues(typeof(SubathonCommandType)))
+            {
+                if (commandType == SubathonCommandType.None || commandType == SubathonCommandType.Unknown) continue;
+                // 200 | 30 blank | 200 | 120 | 120 | remain
+                // enum / blank / name / mods / vips / whitelist 
+                bool.TryParse(Config.Data["Twitch"][$"Commands.{commandType}.permissions.Mods"] ?? "false", out var checkMods);
+                bool.TryParse(Config.Data["Twitch"][$"Commands.{commandType}.permissions.VIPs"] ?? "false", out var checkVips);
+                string name = Config.Data["Twitch"][$"Commands.{commandType}.name"] ?? commandType.ToString().ToLower();
+                string whitelist = (Config.Data["Twitch"][$"Commands.{commandType}.permissions.Whitelist"] ?? "");
+
+                StackPanel entryPanel = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Height = 40
+                };
+                
+                TextBlock enumType = new TextBlock
+                {
+                    Text = commandType.ToString(),
+                    Width = 200,
+                    Margin = new Thickness(0, 0, 30, 0),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                };
+
+                TextBox enumName = new TextBox
+                {
+                    Text = name,
+                    Width = 200,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                };
+
+                CheckBox doMods = new CheckBox
+                {
+                    IsChecked = checkMods,
+                    Width = 120,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    ToolTip = "Allow Mods",
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                };
+
+                CheckBox doVips = new CheckBox
+                {
+                    IsChecked = checkVips,
+                    Width = 120,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    ToolTip = "Allow VIPs",
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                };
+
+                TextBox enumWhitelist = new TextBox
+                {
+                    Text = whitelist,
+                    Width = 456,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                };
+
+                entryPanel.Children.Add(enumType);
+                entryPanel.Children.Add(enumName);
+                entryPanel.Children.Add(doMods);
+                entryPanel.Children.Add(doVips);
+                entryPanel.Children.Add(enumWhitelist);
+
+                CommandListPanel.Children.Add(entryPanel);
+            }   
+        }
+        
+        private void UpdateCommandSettings()
+        {
+            bool updated = false;
+            foreach (var child in CommandListPanel.Children)
+            {
+                if (child is StackPanel entry)
+
+                    if (entry.Children[0] is TextBlock enumType)
+                    {
+                        string key = $"Commands.{enumType.Text}";
+                        
+                        if (entry.Children[1] is TextBox enumName &&
+                            Config.Data["Twitch"][$"{key}.name"] != enumName.Text.Trim())
+                        {
+                            updated = true;
+                            Config.Data["Twitch"][$"{key}.name"] = enumName.Text.Trim();
+                        }
+                    
+                        if (entry.Children[2] is CheckBox doMods &&
+                            Config.Data["Twitch"][$"{key}.permissions.Mods"] != $"{doMods.IsChecked}")
+                        {
+                            updated = true;
+                            Config.Data["Twitch"][$"{key}.permissions.Mods"] = $"{doMods.IsChecked}";
+                        }
+
+                        if (entry.Children[3] is CheckBox doVips &&
+                            Config.Data["Twitch"][$"{key}.permissions.VIPs"] != $"{doVips.IsChecked}")
+                        {
+                            updated = true;
+                            Config.Data["Twitch"][$"{key}.permissions.VIPs"] = $"{doVips.IsChecked}";
+                        }
+
+                        if (entry.Children[4] is TextBox whitelist &&
+                            Config.Data["Twitch"][$"{key}.permissions.Whitelist"] != whitelist.Text.Trim())
+                        {
+                            updated = true;
+                            Config.Data["Twitch"][$"{key}.permissions.Whitelist"] = whitelist.Text.Trim();
+                        }
+                    }
+            }
+            Config.Save();
+            if (updated)
+            {
+                TwitchEvents.RaiseCommandSettingsUpdated();
+            }
+        }
+
+        
         private void InitWebhookSettings()
         {
             foreach (SubathonEventType eventType in Enum.GetValues(typeof(SubathonEventType)))
@@ -249,9 +369,11 @@ namespace SubathonManager.UI.Views
             Config.Data["Twitch"]["LockOnEnd"] = TwitchLockOnEndBx.IsChecked.ToString();
             Config.Data["Twitch"]["ResumeOnStart"] = TwitchResumeOnStartBx.IsChecked.ToString();
             Config.Data["Twitch"]["UnlockOnStart"] = TwitchUnlockOnStartBx.IsChecked.ToString();
-                
-            UpdateWebhookSettings(); // also calls save
             
+            UpdateCommandSettings();
+            
+            UpdateWebhookSettings(); // also calls save
+
         }
 
         private void LoadValues()
@@ -329,7 +451,7 @@ namespace SubathonManager.UI.Views
                         box2 = SLTipBox2;
                         break;
                 }
-                
+
                 if (box != null && box.Text != v) box.Text = v;
                 if (box2 != null && box2.Text != p) box2.Text = p;
             }

--- a/SubathonManager.UI/Views/SettingsView.xaml
+++ b/SubathonManager.UI/Views/SettingsView.xaml
@@ -405,9 +405,28 @@
                         </Expander>
                         
                         <!-- Commands --> 
-                        <Expander Header="Commands" IsExpanded="False">
+                        <Expander Header="Chat Commands" IsExpanded="False">
                             <StackPanel Margin="10,5,0,5">
-                                <!-- TODO commands -->
+                                <!-- EnumName |       | TBX Name | Cbx Mods | Cbx VIPs | Tbx Whitelist  -->
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="200"/>
+                                        <ColumnDefinition Width="30"/>
+                                        <ColumnDefinition Width="200"/>
+                                        <ColumnDefinition Width="120"/>
+                                        <ColumnDefinition Width="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="Command" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="2" Text="Name" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="3" Text="Mods?" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="4" Text="VIPs?" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="5" Text="User Whitelist" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                </Grid>
+                                <Separator Margin="4 4"/>
+                                <StackPanel x:Name="CommandListPanel" Margin="8 4">
+                                    
+                                </StackPanel>
                             </StackPanel>
                         </Expander>
 

--- a/SubathonManager.UI/Views/SettingsView.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsView.xaml.cs
@@ -35,6 +35,7 @@ public partial class SettingsView
         LoadValues();
         InitWebhookSettings();
         InitTwitchAutoSettings();
+        InitCommandSettings();
         
         SubathonEvents.SubathonDataUpdate += UpdateTimerValue;
         WebServerEvents.WebServerStatusChanged += UpdateServerStatus;


### PR DESCRIPTION
Initial framework for configuring chat commands and permissions from the UI, as well as auto population, saving, and firing of update event if any have been changed on config save.

This is not the implementation of the commands, but simply the config implementation.

links to #5
links to #22

<img width="1480" height="818" alt="SubathonManager_8jCypjkp41" src="https://github.com/user-attachments/assets/b4fc85e1-db1c-4039-a7dc-ee9ab83159e9" />

