### PR TITLE
support event overrides during locked state, yt redirect support

### DIFF
--- a/SubathonManager.Core/Enums/SubathonEventType.cs
+++ b/SubathonManager.Core/Enums/SubathonEventType.cs
@@ -65,7 +65,9 @@ public enum SubathonEventType
     [GoAffProTypeMeta(Label="Orchid Eight Order", Source=SubathonEventSource.GoAffPro, IsOrder = true, Order = 3, StoreSource = GoAffProSource.OrchidEight)]
     OrchidEightOrder,
     [GoAffProTypeMeta(Label="KatDragonz Order", Source=SubathonEventSource.GoAffPro, IsOrder = true, Order = 4, StoreSource = GoAffProSource.KatDragonz)]
-    KatDragonzOrder
+    KatDragonzOrder,
+    [EventTypeMeta(Label="Redirect/Raid", Source=SubathonEventSource.YouTube, IsRaid = true, Order = 5)]
+    YouTubeRedirect
     // any new must be added after the last
 }
 

--- a/SubathonManager.Core/Events/SettingsEvents.cs
+++ b/SubathonManager.Core/Events/SettingsEvents.cs
@@ -6,9 +6,15 @@ namespace SubathonManager.Core.Events;
 public static class SettingsEvents
 {
     public static event Action<bool>? SettingsUnsavedChanges;
+    public static event Action? EventVisibilityChanged;
  
     public static void RaiseSettingsUnsavedChanges(bool hasPendingChanges)
     {
         SettingsUnsavedChanges?.Invoke(hasPendingChanges);
+    }
+
+    public static void RaiseEventVisibilityChanged()
+    {
+        EventVisibilityChanged?.Invoke();
     }
 }

--- a/SubathonManager.Data/DbContext.cs
+++ b/SubathonManager.Data/DbContext.cs
@@ -326,7 +326,8 @@ namespace SubathonManager.Data
                 new SubathonValue { EventType = SubathonEventType.UwUMarketOrder,  Seconds = 12 },
                 new SubathonValue { EventType = SubathonEventType.OrchidEightOrder,  Seconds = 12 },
                 new SubathonValue { EventType = SubathonEventType.KatDragonzOrder,  Seconds = 12 },
-                new SubathonValue { EventType = SubathonEventType.ExternalSub, Meta = "DEFAULT", Seconds = 60, Points = 1}
+                new SubathonValue { EventType = SubathonEventType.ExternalSub, Meta = "DEFAULT", Seconds = 60, Points = 1},
+                new SubathonValue { EventType = SubathonEventType.YouTubeRedirect, Seconds = 0 }
             };
 
             foreach (var def in defaults)

--- a/SubathonManager.Integration/SubathonManager.Integration.csproj
+++ b/SubathonManager.Integration/SubathonManager.Integration.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Agash.YTLiveChat" Version="4.1.0" />
+      <PackageReference Include="Agash.YTLiveChat" Version="4.2.0-dev3" />
       <PackageReference Include="GoAffPro.Client" Version="0.4.0" />
       <PackageReference Include="StreamElements.WebSocket" Version="1.0.2" />
       <PackageReference Include="Streamlabs.SocketClient" Version="3.0.0" />

--- a/SubathonManager.Integration/YouTubeService.cs
+++ b/SubathonManager.Integration/YouTubeService.cs
@@ -58,6 +58,7 @@ public class YouTubeService : IDisposable, IAppService
         _ytLiveChat.ChatStopped += OnChatStopped;
         _ytLiveChat.ErrorOccurred += OnErrorOccurred;
         //_ytLiveChat.LivestreamStarted += OnStreamStart;
+        _ytLiveChat.BannerAdded += OnBanner;
         _ytLiveChat.LivestreamEnded += OnStreamEnd; 
         
 #pragma warning restore CS0618
@@ -152,6 +153,24 @@ public class YouTubeService : IDisposable, IAppService
             Status = Running
         });
         TryReconnectLoop();
+    }
+    
+    private void OnBanner(object? sender, BannerAddedEventArgs e)
+    {
+        if (e.Banner.BannerType != BannerType.CrossChannelRedirect || e.Banner is not CrossChannelRedirectBannerItem banner) return;
+        if (banner.RedirectType != CrossChannelRedirectType.Raid) return;
+
+        var channel = banner.RedirectChannelHandle.Replace("@", "");
+
+        SubathonEvent subathonEvent = new SubathonEvent
+        {
+            Source = SubathonEventSource.YouTube,
+            EventType = SubathonEventType.YouTubeRedirect,
+            Value = "",
+            User = channel,
+            Amount = 1
+        };
+        SubathonEvents.RaiseSubathonEventCreated(subathonEvent);
     }
 
     private void OnErrorOccurred(object? sender, ErrorOccurredEventArgs e)
@@ -428,6 +447,7 @@ public class YouTubeService : IDisposable, IAppService
             _ytLiveChat.InitialPageLoaded -= OnInitialPageLoaded;
             _ytLiveChat.ChatReceived -= OnChatReceived;
             _ytLiveChat.ChatStopped -= OnChatStopped;
+            _ytLiveChat.BannerAdded -= OnBanner;
             _ytLiveChat.ErrorOccurred -= OnErrorOccurred;
             _ytLiveChat.Dispose();
             _httpClient.Dispose();
@@ -475,6 +495,20 @@ public class YouTubeService : IDisposable, IAppService
             Value = tier,
             User = "SYSTEM",
             Amount = amount
+        };
+        SubathonEvents.RaiseSubathonEventCreated(subathonEvent);
+    } 
+    
+    public static void SimulateRaid()
+    {
+        SubathonEvent subathonEvent = new SubathonEvent
+        {
+            Source = SubathonEventSource.Simulated,
+            Currency = "",
+            EventType = SubathonEventType.YouTubeRedirect,
+            Value = "",
+            User = "SYSTEM",
+            Amount = 1
         };
         SubathonEvents.RaiseSubathonEventCreated(subathonEvent);
     } 

--- a/SubathonManager.Server/WebServer.WebSocket.cs
+++ b/SubathonManager.Server/WebServer.WebSocket.cs
@@ -181,7 +181,8 @@ public partial class WebServer
 
     internal void SendSubathonEventProcessed(SubathonEvent subathonEvent, bool effective)
     {
-        if (!subathonEvent.ProcessedToSubathon) return;
+        bool showOverride = _config.GetBool("App", "ShowLockedEvents", false);
+        if (!showOverride && !subathonEvent.ProcessedToSubathon) return;
         Task.Run(() => BroadcastAsyncObject(SubathonEventToObject(subathonEvent), WebsocketClientTypeHelper.ConsumersList));
     }
 

--- a/SubathonManager.Services/EventService.cs
+++ b/SubathonManager.Services/EventService.cs
@@ -274,8 +274,17 @@ public class EventService: IDisposable, IAppService
         {
             ev.ProcessedToSubathon = true;
         }
+
+        if (ev.EventType.IsCurrencyDonation() && !_currencyService.IsValidCurrency(ev.Currency))
+        {
+            ev.ProcessedToSubathon = false;
+            // discord push error donation
+            ErrorMessageEvents.RaiseErrorEvent("WARN", ev.Source.ToString(), 
+                $"{ev.EventType} invalid currency donated. Amt: [{ev.Value}] Currency: [{ev.Currency}]", ev.EventTimestamp);
+        }
         
-        if (affected > 0 || ev.EventType == SubathonEventType.DonationAdjustment || (processPointsIfLocked && subathon.IsLocked && ev.EventType.IsCurrencyDonation()) ||
+        if (affected > 0 || ev.EventType == SubathonEventType.DonationAdjustment ||
+            (processPointsIfLocked && subathon.IsLocked && ev.EventType.IsCurrencyDonation() && _currencyService.IsValidCurrency(ev.Currency)) ||
             (ev.EventType.IsOrder() && _config.GetBool(ev.EventType.GetSource().ToString(),
                                             $"{ev.EventType.ToString()?.Split("Order")[0]}.CommissionAsDonation", false)
                                         && !string.IsNullOrWhiteSpace(ev.SecondaryValue) && ev.SecondaryValue.Contains('|')))

--- a/SubathonManager.Services/EventService.cs
+++ b/SubathonManager.Services/EventService.cs
@@ -40,11 +40,11 @@ public class EventService: IDisposable, IAppService
     public Task StartAsync(CancellationToken ct = default)
     {
         Core.Events.SubathonEvents.SubathonEventCreated += AddSubathonEvent;
-        _processingTask = Task.Run(LoopAsync);
+        _processingTask = Task.Run(LoopAsync, ct);
         _processingTask.ContinueWith(t => 
                 _logger?.LogError("Event loop crashed: {AggregateException}", t.Exception), 
             TaskContinuationOptions.OnlyOnFaulted);
-        Task.Run(() =>_currencyService.StartAsync(ct));
+        Task.Run(() =>_currencyService.StartAsync(ct), ct);
         _logger?.LogInformation("EventService started");
         return Task.CompletedTask;
     }
@@ -122,8 +122,9 @@ public class EventService: IDisposable, IAppService
             var (bool1, bool2, hasRun) =  await HandleCommandEvent(ev, db, subathon, goalSet, initialPoints);
             if (hasRun) return (bool1, bool2);
         }
-        
-        if (subathon == null || (subathon.IsLocked && ev.EventType != SubathonEventType.TwitchHypeTrain)) // we only do math if it's unlocked, otherwise, only link
+
+        var processPointsIfLocked = _config.GetBool("App", "OtherValuesWhenLocked", true);
+        if (subathon == null || (subathon.IsLocked && ev.EventType != SubathonEventType.TwitchHypeTrain && !processPointsIfLocked)) // we only do math if it's unlocked, otherwise, only link
         {
             ev.ProcessedToSubathon = false;
             if (subathon != null)
@@ -245,6 +246,7 @@ public class EventService: IDisposable, IAppService
         }
 
         int affected = 0;
+        if (processPointsIfLocked && subathon.IsLocked) ev.SecondsValue = 0;
         if (ev.SecondsValue != 0)
         {
             if (ev.WasReversed)
@@ -261,9 +263,11 @@ public class EventService: IDisposable, IAppService
 
         if (ev.PointsValue != 0)
         {
+            var lockVal = 0;
+            if (subathon.IsLocked && processPointsIfLocked) lockVal = 1;
             affected += await db.Database.ExecuteSqlRawAsync(
-                "UPDATE SubathonDatas SET Points = Points + {0} WHERE IsActive = 1 AND IsLocked = 0 AND Id = {1}",
-                (int)ev.GetFinalPointsValue(), subathon.Id);
+                "UPDATE SubathonDatas SET Points = Points + {0} WHERE IsActive = 1 AND IsLocked = {2} AND Id = {1}",
+                (int)ev.GetFinalPointsValue(), subathon.Id, lockVal);
         }
 
         if (ev is { PointsValue: 0, SecondsValue: 0 } && ev.Currency != "???")
@@ -271,13 +275,16 @@ public class EventService: IDisposable, IAppService
             ev.ProcessedToSubathon = true;
         }
         
-        if (affected > 0 || ev.EventType == SubathonEventType.DonationAdjustment || 
+        if (affected > 0 || ev.EventType == SubathonEventType.DonationAdjustment || (processPointsIfLocked && subathon.IsLocked && ev.EventType.IsCurrencyDonation()) ||
             (ev.EventType.IsOrder() && _config.GetBool(ev.EventType.GetSource().ToString(),
                                             $"{ev.EventType.ToString()?.Split("Order")[0]}.CommissionAsDonation", false)
                                         && !string.IsNullOrWhiteSpace(ev.SecondaryValue) && ev.SecondaryValue.Contains('|')))
         {
             ev.ProcessedToSubathon = true;
             (bool asDono, double modifier) = Utils.GetAltCurrencyUseAsDonation(_config, ev.EventType);
+            
+            var lockVal = 0;
+            if (subathon.IsLocked && processPointsIfLocked) lockVal = 1;
             
             if (ev.EventType.IsOrder() && _config.GetBool(ev.EventType.GetSource().ToString(),
                                            $"{ev.EventType.ToString()?.Split("Order")[0]}.CommissionAsDonation", false)
@@ -289,10 +296,10 @@ public class EventService: IDisposable, IAppService
                 {
                     double added = await _currencyService.ConvertAsync(double.Parse(value), currency,
                         _config.Get("Currency", "Primary", "USD"));
-
-                    await db.Database.ExecuteSqlRawAsync(
-                        "UPDATE SubathonDatas SET MoneySum = MoneySum + {0} WHERE IsActive = 1 AND IsLocked = 0 AND Id = {1}",
-                        added, subathon.Id);
+                    affected += await db.Database.ExecuteSqlRawAsync(
+                        "UPDATE SubathonDatas SET MoneySum = MoneySum + {0} WHERE IsActive = 1 AND IsLocked = {2} AND Id = {1}",
+                        added, subathon.Id, lockVal);
+                    
                 }
 
             }
@@ -303,17 +310,17 @@ public class EventService: IDisposable, IAppService
                 double added = await _currencyService.ConvertAsync(double.Parse(value), ev.Currency,
                         _config.Get("Currency", "Primary", "USD"));
 
-                await db.Database.ExecuteSqlRawAsync(
-                    "UPDATE SubathonDatas SET MoneySum = MoneySum + {0} WHERE IsActive = 1 AND IsLocked = 0 AND Id = {1}",
-                    added, subathon.Id);
+                affected += await db.Database.ExecuteSqlRawAsync(
+                    "UPDATE SubathonDatas SET MoneySum = MoneySum + {0} WHERE IsActive = 1 AND IsLocked = {2} AND Id = {1}",
+                    added, subathon.Id, lockVal);
             }
             else if (asDono)
             {
                 double added = await _currencyService.ConvertAsync((double.Parse(ev.Value) * modifier) / 100, "USD",
                     _config.Get("Currency", "Primary", "USD"));
-                await db.Database.ExecuteSqlRawAsync(
-                    "UPDATE SubathonDatas SET MoneySum = MoneySum + {0} WHERE IsActive = 1 AND IsLocked = 0 AND Id = {1}",
-                    added, subathon.Id);
+                affected += await db.Database.ExecuteSqlRawAsync(
+                    "UPDATE SubathonDatas SET MoneySum = MoneySum + {0} WHERE IsActive = 1 AND IsLocked = {2} AND Id = {1}",
+                    added, subathon.Id, lockVal);
                 
             }
             

--- a/SubathonManager.Tests/SequentialCollectionDefinition.cs
+++ b/SubathonManager.Tests/SequentialCollectionDefinition.cs
@@ -12,3 +12,6 @@ public class SequentialParallelCollectionDefinition
 
 [CollectionDefinition("SharedEventBusTests", DisableParallelization = true)] // slowdown but might fix the eventbus issue in websocket consumers
 public class SharedEventBusTestsCollection { }
+
+[CollectionDefinition("NonParallel", DisableParallelization = true)]
+public class NonParallelCollection { }

--- a/SubathonManager.Tests/ServerUnitTests/WebServerWebSocketTests.cs
+++ b/SubathonManager.Tests/ServerUnitTests/WebServerWebSocketTests.cs
@@ -14,6 +14,36 @@ using SubathonManager.Tests.Utility;
 
 namespace SubathonManager.Tests.ServerUnitTests;
 
+[Collection("NonParallel")]
+public class WebServerWebSocketEventBusEnforcedSequentialTests
+{
+    
+    [Fact]
+    public async Task WebSocket_SendRefreshRequest_NoConsumers()
+    {
+        /*
+         * Fails 1 in like 10 runs due to parallel stuff
+         */
+        var server = WebServerWebSocketTests.CreateServer();
+        WebServerWebSocketTests.SetupServices();
+        var ctx = new MockHttpContext
+        {
+            IsWebSocket = true
+        };
+        
+        await server.HandleWebSocketRequestAsync(ctx);
+        WebSocketClient client = new WebSocketClient(ctx.Socket);
+        client.ClientTypes.Add(WebsocketClientMessageType.Widget);
+        server.AddSocketClient(client);
+        Guid guid = Guid.Empty;
+        server.SendRefreshRequest(guid);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+        Assert.Empty(ctx.Socket.SentMessages);
+        AppServices.Provider = null!;
+        await server.StopAsync(TestContext.Current.CancellationToken);
+    }
+}
+
 [Collection("SharedEventBusTests")]
 public class WebServerWebSocketEventBusTests
 {
@@ -465,31 +495,6 @@ public class WebServerWebSocketTests(ITestOutputHelper testOutputHelper)
             .Select(m => Encoding.UTF8.GetString(m))
             .First(m => m.Contains("refresh_request"));
         Assert.Equal($"{{\"type\":\"refresh_request\",\"id\":\"{guid}\"}}", sent);
-        AppServices.Provider = null!;
-        await server.StopAsync(TestContext.Current.CancellationToken);
-    }
-    
-    [Fact]
-    public async Task WebSocket_SendRefreshRequest_NoConsumers()
-    {
-        /*
-         * Fails 1 in like 10 runs due to parallel stuff
-         */
-        var server = CreateServer();
-        SetupServices();
-        var ctx = new MockHttpContext
-        {
-            IsWebSocket = true
-        };
-        
-        await server.HandleWebSocketRequestAsync(ctx);
-        WebSocketClient client = new WebSocketClient(ctx.Socket);
-        client.ClientTypes.Add(WebsocketClientMessageType.Widget);
-        server.AddSocketClient(client);
-        Guid guid = Guid.Empty;
-        server.SendRefreshRequest(guid);
-        await Task.Delay(50, TestContext.Current.CancellationToken);
-        Assert.Empty(ctx.Socket.SentMessages);
         AppServices.Provider = null!;
         await server.StopAsync(TestContext.Current.CancellationToken);
     }

--- a/SubathonManager.Tests/ServicesUnitTests/EventServiceTests.cs
+++ b/SubathonManager.Tests/ServicesUnitTests/EventServiceTests.cs
@@ -61,7 +61,7 @@ public class EventServiceTests
     }
 
     internal static async Task<(EventService, DbContextOptions<AppDbContext>,
-        Microsoft.Data.Sqlite.SqliteConnection)> SetupServiceWithDb(int initialPoints = 10, bool isLocked = true)
+        Microsoft.Data.Sqlite.SqliteConnection)> SetupServiceWithDb(int initialPoints = 10, bool isLocked = true, bool showEventsState = false, bool allowPointsLocked = true)
     {
         var dbName = $"test_{Guid.NewGuid():N}";
         var connectionString = $"DataSource={dbName};Mode=Memory;Cache=Shared";
@@ -122,6 +122,8 @@ public class EventServiceTests
                 { ("Twitch", "HypeTrainMultiplier.Points"), "True" },
                 { ("Twitch", "HypeTrainMultiplier.Time"), "True" },
                 { ("Twitch", "HypeTrainMultiplier.Multiplier"), "2" },
+                { ("App", "OtherValuesWhenLocked"), allowPointsLocked.ToString()},
+                { ("App", "ShowLockedEvents"), showEventsState.ToString()}
             }), SetupCurrencyService());
         await service.StartAsync();
 
@@ -280,7 +282,7 @@ public class EventServiceTests
     [Fact]
     public async Task DonationEvent_CalculatesPointsAndSeconds()
     {
-        var (service, options, conn) = await SetupServiceWithDb();
+        var (service, options, conn) = await SetupServiceWithDb(allowPointsLocked: false);
         var ev = new SubathonEvent
         {
             Id = Guid.NewGuid(),
@@ -554,7 +556,7 @@ public class EventServiceTests
     [Fact]
     public async Task Event_WithLockedSubathon_DoesNotUpdatePoints()
     {
-        var (service, options, conn) = await SetupServiceWithDb();
+        var (service, options, conn) = await SetupServiceWithDb(allowPointsLocked: false);
 
         await using var db = new AppDbContext(options);
         var sub = await db.SubathonDatas.FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
@@ -1118,10 +1120,13 @@ public class EventServiceTests
         await conn.CloseAsync();
     }
 
-    [Fact]
-    public async Task ProcessSubathonEvent_SubathonLocked_NonHypeTrain_SavesButReturnsFalse()
+    [Theory]
+    
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ProcessSubathonEvent_SubathonLocked_NonHypeTrain_SavesButReturnsFalse(bool allowValuesWhenLocked)
     {
-        var (service, options, conn) = await SetupServiceWithDb(0, true);
+        var (service, options, conn) = await SetupServiceWithDb(0, true, false, allowValuesWhenLocked);
 
         var ev = new SubathonEvent
         {
@@ -1132,13 +1137,13 @@ public class EventServiceTests
         };
 
         var (processed, dupe) = await service.ProcessSubathonEvent(ev);
-        Assert.False(processed);
+        Assert.Equal(processed, allowValuesWhenLocked);
         Assert.False(dupe);
 
         await using var db = new AppDbContext(options);
         var stored = await db.SubathonEvents.FirstOrDefaultAsync(e => e.Id == ev.Id, cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(stored);
-        Assert.False(stored.ProcessedToSubathon);
+        Assert.Equal(stored.ProcessedToSubathon, allowValuesWhenLocked);
         Assert.NotNull(stored.SubathonId);
         Assert.True(stored.CurrentTime >= 0);
         Assert.True(stored.CurrentPoints >= 0);
@@ -1212,14 +1217,14 @@ public class EventServiceTests
         };
 
         var (processed, dupe) = await service.ProcessSubathonEvent(ev);
-        Assert.True(processed);
+        Assert.False(processed);
 
         await using var db = new AppDbContext(options);
         var saved = await db.SubathonEvents.FirstOrDefaultAsync(e => e.Id == ev.Id, cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(saved);
         Assert.Equal(0, saved.PointsValue);
         Assert.Equal(0, saved.SecondsValue);
-        Assert.True(saved.ProcessedToSubathon);
+        Assert.False(saved.ProcessedToSubathon);
 
         await service.StopAsync(TestContext.Current.CancellationToken);
         await conn.CloseAsync();
@@ -1544,7 +1549,7 @@ public class EventServiceSequentialTests
 
         var (processed, _) = await service.ProcessSubathonEvent(ev);
         await service.StopAsync(TestContext.Current.CancellationToken);
-        Assert.True(processed); // will have 0 values
+        Assert.False(processed); // will have 0 values
 
         await using var db = new AppDbContext(options);
         var sub = await db.SubathonDatas.FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
@@ -1553,7 +1558,7 @@ public class EventServiceSequentialTests
 
         var ev2 = await db.SubathonEvents.FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
         Assert.Equal("EEE", ev2.Currency);
-        Assert.True(ev2.ProcessedToSubathon);
+        Assert.False(ev2.ProcessedToSubathon);
         Assert.Equal(0, ev2.PointsValue);
         Assert.Equal(0, ev2.SecondsValue);
 

--- a/SubathonManager.Tests/ServicesUnitTests/EventServiceTests.cs
+++ b/SubathonManager.Tests/ServicesUnitTests/EventServiceTests.cs
@@ -1447,12 +1447,12 @@ public class EventServiceTests
         var (processed, _) = await service.ProcessSubathonEvent(ev);
         Assert.True(processed);
 
+        await service.StopAsync(TestContext.Current.CancellationToken);
         await using var db = new AppDbContext(options);
         var saved = await db.SubathonEvents.FirstOrDefaultAsync(e => e.Id == ev.Id, cancellationToken: TestContext.Current.CancellationToken);
         Assert.NotNull(saved);
         Assert.True(double.Parse(saved.Value) < 0);
 
-        await service.StopAsync(TestContext.Current.CancellationToken);
         await conn.CloseAsync();
     }
 

--- a/SubathonManager.UI/Views/EventListView.xaml.cs
+++ b/SubathonManager.UI/Views/EventListView.xaml.cs
@@ -6,6 +6,7 @@ using SubathonManager.Core.Enums;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Events;
 using SubathonManager.Core;
+using SubathonManager.Core.Interfaces;
 using SubathonManager.Data;
 using SubathonManager.UI.Services;
 
@@ -16,16 +17,19 @@ namespace SubathonManager.UI.Views
         public ObservableCollection<SubathonEvent> EventItems { get; set; } = new();
         private int _maxItems = 20;
         private readonly IDbContextFactory<AppDbContext> _factory;
+        private readonly IConfig _config;
 
         public EventListView()
         {
-            _factory = AppServices.Provider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
+            _factory = AppServices.Provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
             InitializeComponent();
             EventListPanel.ItemsSource = EventItems;
             Task.Run(async () => await LoadRecentEvents());
 
             SubathonEvents.SubathonEventProcessed += OnSubathonEventProcessed;
             SubathonEvents.SubathonEventsDeleted += OnSubathonEventsDeleted;
+            SettingsEvents.EventVisibilityChanged += OnEventVisibilityChanged;
+            _config = AppServices.Provider.GetRequiredService<IConfig>();
         }
 
         private void OnSubathonEventsDeleted(List<SubathonEvent> events)
@@ -33,9 +37,16 @@ namespace SubathonManager.UI.Views
             Task.Run(async () => await LoadRecentEvents());
         }
 
+        private void OnEventVisibilityChanged()
+        {
+            Task.Run(async () => await LoadRecentEvents());
+        }
+
         private async void OnSubathonEventProcessed(SubathonEvent subathonEvent, bool wasEffective)
         {
-            if (subathonEvent.PointsValue < 1 
+            bool showOverride = _config.GetBool("App", "ShowLockedEvents", false);
+            
+            if (!showOverride && subathonEvent.PointsValue < 1 
                 && subathonEvent.GetFinalSecondsValueRaw() <= 0
                 && subathonEvent.EventType != SubathonEventType.Command
                 && subathonEvent.EventType != SubathonEventType.DonationAdjustment
@@ -55,13 +66,14 @@ namespace SubathonManager.UI.Views
 
         private async Task LoadRecentEvents()
         {
+            bool showOverride = _config.GetBool("App", "ShowLockedEvents", false);
             await using var db = await _factory.CreateDbContextAsync();
             SubathonData? subathon = await db.SubathonDatas.AsNoTracking().FirstOrDefaultAsync(s => s.IsActive);
             List<SubathonEvent> events = new();
             if (subathon != null)
             {
                 events = await db.SubathonEvents.Where(ev => ev.SubathonId == subathon.Id 
-                                                             && (ev.SecondsValue > 0 || ev.PointsValue >= 1 
+                                                             && (showOverride || ev.SecondsValue > 0 || ev.PointsValue >= 1 
                                                                  || ev.Command != SubathonCommandType.None
                                                                  || ev.EventType == SubathonEventType.TwitchHypeTrain
                                                                  || ev.EventType == SubathonEventType.DonationAdjustment

--- a/SubathonManager.UI/Views/SettingsView.Settings.cs
+++ b/SubathonManager.UI/Views/SettingsView.Settings.cs
@@ -76,7 +76,14 @@ namespace SubathonManager.UI.Views
             
             var config = AppServices.Provider.GetRequiredService<IConfig>();
             hasUpdated |= config.Set("Currency", "BitsLikeAsDonation", $"{BitsAsCurrencyBox.IsChecked}");
+            hasUpdated |= config.Set("App", "OtherValuesWhenLocked", $"{AddOtherWhenLockedBox.IsChecked}");
             
+            bool updatedLockVisibility = config.Set("App", "ShowLockedEvents", $"{ShowEventsWhenLockedBox.IsChecked}");
+            hasUpdated |= updatedLockVisibility;
+            if (updatedLockVisibility)
+            {
+                SettingsEvents.RaiseEventVisibilityChanged();
+            }
 
             if (selectedCurrency.Length >= 3)
             {
@@ -249,6 +256,13 @@ namespace SubathonManager.UI.Views
                 var config = AppServices.Provider.GetRequiredService<IConfig>();
                 bool bitsAsDonation = config.GetBool("Currency", "BitsLikeAsDonation", false);
                 BitsAsCurrencyBox.IsChecked = bitsAsDonation;
+                
+                
+                bool otherWhenLocked = config.GetBool("App", "OtherValuesWhenLocked", true);
+                AddOtherWhenLockedBox.IsChecked =  otherWhenLocked;
+                
+                bool showWhenLocked = config.GetBool("App", "ShowLockedEvents", false);
+                ShowEventsWhenLockedBox.IsChecked = showWhenLocked;
                 
                 var theme = config.Get("App", "Theme", "Dark")!;
                 foreach (ComboBoxItem item in ThemeBox.Items)

--- a/SubathonManager.UI/Views/SettingsView.xaml
+++ b/SubathonManager.UI/Views/SettingsView.xaml
@@ -82,9 +82,13 @@
                                     <ComboBoxItem Content="Dark"/>
                                     <ComboBoxItem Content="Light"/>
                                 </ComboBox>
+                                <CheckBox x:Name="ShowEventsWhenLockedBox" Margin="4 0 4 0" ToolTip="When the timer is locked, still show events that come in"
+                                          Content="Events when Locked?"/>
                             </StackPanel>
                             <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Left" Margin="0 4 0 0">
                                 <Button x:Name="TelemetryBtn" Content="Data Collection" Margin="2 0 4 0" Width = "222" Click="ShowTelemetryPromptAsync"/>
+                                <CheckBox x:Name="AddOtherWhenLockedBox" Margin="4 0 4 0" ToolTip="When the timer is locked, still add points and donations amounts"
+                                          Content="Values when Locked?"/>
                             </StackPanel>
                         </Grid>
                         

--- a/SubathonManager.UI/Views/SettingsViews/Streaming/YouTubeSettings.Simulate.cs
+++ b/SubathonManager.UI/Views/SettingsViews/Streaming/YouTubeSettings.Simulate.cs
@@ -22,6 +22,11 @@ public partial class YouTubeSettings : SettingsControl
         YouTubeService.SimulateMembership(selectedTier);
     }
 
+    private void TestYTRaid_Click(object sender, RoutedEventArgs e)
+    {
+        YouTubeService.SimulateRaid();
+    }
+    
     private void TestYTGiftMembership_Click(object sender, RoutedEventArgs e)
     {
         int amount = int.TryParse(SimGiftMembershipAmtInput.Text, out var parsedAmountInt) ? parsedAmountInt : 0;

--- a/SubathonManager.UI/Views/SettingsViews/Streaming/YouTubeSettings.xaml
+++ b/SubathonManager.UI/Views/SettingsViews/Streaming/YouTubeSettings.xaml
@@ -60,7 +60,30 @@
                 </Grid>
 
                 
-                
+                <Grid Margin="0,2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="300"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Orientation="Horizontal">
+                        <TextBlock Text="Redirects:" Width="100" VerticalAlignment="Center" ToolTip="YT Does not expose number of raiders"/>
+                        <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True" PlaceholderText="0"
+                                    x:Name="RaidBox"/>
+                        <TextBlock Margin="8 0 0 0" Text="Seconds per raid" Width="150" VerticalAlignment="Center" ToolTip="YT Does not expose number of raiders"/>
+                        <ui:TextBox Width="100" validation:InputValidationBehavior.IsNumberOnly="True" PlaceholderText="0"
+                                    x:Name="RaidBox2"/>
+                        <TextBlock Margin="8 0 0 0"  Text="Points per raid" Width="180" VerticalAlignment="Center"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <ui:Button Icon="Add24" Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                   Content="Test"
+                                   Click="TestYTRaid_Click"
+                                   Width="60" Padding="2"  Height="34"
+                                   Margin="4,0,0,0"></ui:Button>
+                    </StackPanel>
+                </Grid>
                 <!-- Memberships -->
                 <Expander Header="Memberships" IsExpanded="False" Margin="0,5,0,0">
                     <StackPanel  Margin="10,5,0,5">

--- a/SubathonManager.UI/Views/SettingsViews/Streaming/YouTubeSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/Streaming/YouTubeSettings.xaml.cs
@@ -266,14 +266,14 @@ public partial class YouTubeSettings : SettingsControl
         var redirectValue = db.SubathonValues.FirstOrDefault(sv =>
             sv.EventType == SubathonEventType.YouTubeRedirect
             && sv.Meta == "");
-        if (redirectValue != null && double.TryParse(DonoBox.Text, out var rdSeconds)
+        if (redirectValue != null && double.TryParse(RaidBox.Text, out var rdSeconds)
                                   && !rdSeconds.Equals(redirectValue.Seconds))
         {
             redirectValue.Seconds = rdSeconds;
             hasUpdated = true;
         }
 
-        if (redirectValue != null && double.TryParse(DonoBox2.Text, out var rdPoints)
+        if (redirectValue != null && double.TryParse(RaidBox2.Text, out var rdPoints)
                                   && !rdPoints.Equals(redirectValue.Points))
         {
             redirectValue.Points = rdPoints;
@@ -371,7 +371,7 @@ public partial class YouTubeSettings : SettingsControl
                 box = DonoBox;
                 box2 = DonoBox2;
                 break;
-            case SubathonEventType.TwitchRaid:
+            case SubathonEventType.YouTubeRedirect:
                 box = RaidBox;
                 box2 = RaidBox2;
                 break;

--- a/SubathonManager.UI/Views/SettingsViews/Streaming/YouTubeSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/Streaming/YouTubeSettings.xaml.cs
@@ -261,7 +261,25 @@ public partial class YouTubeSettings : SettingsControl
             superchatValue.Points = scPoints;
             hasUpdated = true;
         }
+        
+        
+        var redirectValue = db.SubathonValues.FirstOrDefault(sv =>
+            sv.EventType == SubathonEventType.YouTubeRedirect
+            && sv.Meta == "");
+        if (redirectValue != null && double.TryParse(DonoBox.Text, out var rdSeconds)
+                                  && !rdSeconds.Equals(redirectValue.Seconds))
+        {
+            redirectValue.Seconds = rdSeconds;
+            hasUpdated = true;
+        }
 
+        if (redirectValue != null && double.TryParse(DonoBox2.Text, out var rdPoints)
+                                  && !rdPoints.Equals(redirectValue.Points))
+        {
+            redirectValue.Points = rdPoints;
+            hasUpdated = true;
+        }
+        
         hasUpdated |= Host.SaveSubTier(db, SubathonEventType.YouTubeMembership, "DEFAULT", MemberDefaultTextBox, MemberDefaultTextBox2);
         hasUpdated |= Host.SaveSubTier(db, SubathonEventType.YouTubeGiftMembership, "DEFAULT", GiftMemberDefaultTextBox, GiftMemberDefaultTextBox2);
         
@@ -352,6 +370,10 @@ public partial class YouTubeSettings : SettingsControl
             case SubathonEventType.YouTubeSuperChat:
                 box = DonoBox;
                 box2 = DonoBox2;
+                break;
+            case SubathonEventType.TwitchRaid:
+                box = RaidBox;
+                box2 = RaidBox2;
                 break;
         }
         return (v, p, box, box2);

--- a/presets/popups/alert/event-alert.html
+++ b/presets/popups/alert/event-alert.html
@@ -288,7 +288,9 @@ END_WIDGET_META
         if (!events.includes(data.event_type)) return;
         if (data.sub_type == "DonationLike" && (typeof minDonationAmount !== "undefined") && minDonationAmount > parseFloat(data.value)) return;
         if (data.sub_type == "TokenLike" && (typeof minTokensAmount !== "undefined") && minTokensAmount > parseInt(data.value)) return;
-        if (data.sub_type == "RaidLike" && (typeof minRaidersAmount !== "undefined") && minRaidersAmount > parseInt(data.value)) return;
+        
+        // if empty value, still goes through, which would be a bug except youtube we want to pass so, happy accident
+        if (data.sub_type == "RaidLike" && (typeof minRaidersAmount !== "undefined") && minRaidersAmount > parseInt(data.value)) return; 
         queue.push(data);
         processQueue();
     }


### PR DESCRIPTION
Allow overriding behaviour during Locked status 

- Show events even if they contribute nothing, so overlays can still show things, and event viewer shows not processed fully.
- Allow points and donation/money values to go through and add when subathon is locked. Essentially meaning locked would ONLY not count seconds.

Note - since some overlays adjust if it's locked, if you truly want no time to be added and still have things look open, just set all events to 0s and keep it unlocked, then allow "show events". 

- Added youtube redirect/raid support, library update