### PR TITLE
Ko-fi webhook + DevTunnels integration, shop orders and commissions

### DIFF
--- a/SubathonManager.Core/Enums/SubathonEventSource.cs
+++ b/SubathonManager.Core/Enums/SubathonEventSource.cs
@@ -29,7 +29,11 @@ public enum SubathonEventSource
     [EventSourceMeta(Description = "Picarto", SourceGroup = SubathonSourceGroup.Stream, SourceOrder=3, Order=12)]
     Picarto,
     [EventSourceMeta(Description = "GoAffPro Affiliate Stores", SourceGroup = SubathonSourceGroup.ExternalService, SourceOrder=61, Order=50)]
-    GoAffPro
+    GoAffPro,
+    [EventSourceMeta(Description = "Ko-fi Webhook", SourceGroup = SubathonSourceGroup.ExternalService, SourceOrder=42, Order=41)]
+    KoFiWebhook,
+    [EventSourceMeta(Description = "Dev Tunnels", SourceGroup = SubathonSourceGroup.ExternalService, SourceOrder=70, Order=60)]
+    DevTunnels
 }
 
 [ExcludeFromCodeCoverage]

--- a/SubathonManager.Core/Enums/SubathonEventType.cs
+++ b/SubathonManager.Core/Enums/SubathonEventType.cs
@@ -67,7 +67,9 @@ public enum SubathonEventType
     [GoAffProTypeMeta(Label="KatDragonz Order", Source=SubathonEventSource.GoAffPro, IsOrder = true, Order = 4, StoreSource = GoAffProSource.KatDragonz)]
     KatDragonzOrder,
     [EventTypeMeta(Label="Redirect/Raid", Source=SubathonEventSource.YouTube, IsRaid = true, Order = 5)]
-    YouTubeRedirect
+    YouTubeRedirect,
+    [EventTypeMeta(Label="Shop Order", Source=SubathonEventSource.KoFi, IsOrder = true, IsExternal=true, Order = 3)]
+    KoFiShopOrder
     // any new must be added after the last
 }
 

--- a/SubathonManager.Core/Enums/SubathonEventType.cs
+++ b/SubathonManager.Core/Enums/SubathonEventType.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 namespace SubathonManager.Core.Enums;
 
 public enum SubathonEventType
@@ -69,7 +69,9 @@ public enum SubathonEventType
     [EventTypeMeta(Label="Redirect/Raid", Source=SubathonEventSource.YouTube, IsRaid = true, Order = 5)]
     YouTubeRedirect,
     [EventTypeMeta(Label="Shop Order", Source=SubathonEventSource.KoFi, IsOrder = true, IsExternal=true, Order = 3)]
-    KoFiShopOrder
+    KoFiShopOrder,
+    [EventTypeMeta(Label="Commission", Source=SubathonEventSource.KoFi, IsOrder = true, IsExternal=true, Order = 4)]
+    KoFiCommissionOrder
     // any new must be added after the last
 }
 

--- a/SubathonManager.Core/Interfaces/IWebhookIntegration.cs
+++ b/SubathonManager.Core/Interfaces/IWebhookIntegration.cs
@@ -1,0 +1,8 @@
+namespace SubathonManager.Core.Interfaces;
+
+public interface IWebhookIntegration : IAppService
+{
+    string WebhookPath { get; }
+
+    Task HandleWebhookAsync(byte[] rawBody, IReadOnlyDictionary<string, string> headers, CancellationToken ct = default);
+}

--- a/SubathonManager.Data/DbContext.cs
+++ b/SubathonManager.Data/DbContext.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using System.Diagnostics;
 using System.Text;
 using SubathonManager.Core.Models;
@@ -311,7 +311,9 @@ namespace SubathonManager.Data
                 new SubathonValue { EventType = SubathonEventType.TwitchCharityDonation, Seconds = 12}, // per 1 unit/dollar of default currency
                 new SubathonValue { EventType = SubathonEventType.ExternalDonation, Seconds = 12}, // per 1 unit/dollar of default currency
                 new SubathonValue { EventType = SubathonEventType.KoFiDonation, Seconds = 12}, // per 1 unit/dollar of default currency
-                new SubathonValue { EventType = SubathonEventType.KoFiSub, Meta = "DEFAULT", Seconds = 60, Points = 1}, // per 1 unit/dollar of default currency
+                new SubathonValue { EventType = SubathonEventType.KoFiSub, Meta = "DEFAULT", Seconds = 60, Points = 1},
+                new SubathonValue { EventType = SubathonEventType.KoFiShopOrder, Seconds = 12}, // per 1 unit/dollar of default currency
+                new SubathonValue { EventType = SubathonEventType.KoFiCommissionOrder, Seconds = 12}, // per 1 unit/dollar of default currency
                 new SubathonValue { EventType = SubathonEventType.BlerpBeets, Seconds = 0.12 },
                 new SubathonValue { EventType = SubathonEventType.BlerpBits, Seconds = 0.12 },
                 new SubathonValue { EventType = SubathonEventType.PicartoSub, Meta = "T1", Seconds = 60, Points = 1 },

--- a/SubathonManager.Integration/DevTunnelsService.cs
+++ b/SubathonManager.Integration/DevTunnelsService.cs
@@ -1,0 +1,282 @@
+using System.Diagnostics.CodeAnalysis;
+using DevTunnels.Client;
+using DevTunnels.Client.Authentication;
+using DevTunnels.Client.Hosting;
+using DevTunnels.Client.Ports;
+using DevTunnels.Client.Tunnels;
+using Microsoft.Extensions.Logging;
+using SubathonManager.Core;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Objects;
+
+namespace SubathonManager.Integration;
+
+public class DevTunnelsService(
+    ILogger<DevTunnelsService>? logger,
+    IConfig config,
+    IDevTunnelsClient client) : IDisposable, IAppService
+{
+    private readonly string _configSection = "DevTunnels";
+    private bool _disposed = false;
+
+    private IDevTunnelHostSession? _session;
+    private CancellationTokenSource? _cts;
+
+    // Serialises concurrent StartTunnelAsync calls so at most one session-start attempt
+    // runs at a time. Without this, two webhook integrations firing StartTunnelAsync
+    // concurrently could both pass the _session != null guard and launch two CLI processes.
+    private readonly SemaphoreSlim _startLock = new(1, 1);
+
+    // Publicly readable so the UI can show the live URL without subscribing to events.
+    public string? PublicBaseUrl { get; private set; }
+    public bool IsCliInstalled { get; private set; }
+    public bool IsLoggedIn { get; private set; }
+    public bool IsTunnelRunning { get; private set; }
+
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        // 1. Probe CLI
+        var probe = await client.ProbeCliAsync(ct);
+        IsCliInstalled = probe.IsInstalled;
+
+        BroadcastCliStatus(probe);
+
+        if (!probe.IsInstalled)
+        {
+            logger?.LogInformation("[DevTunnels] CLI not installed, skipping auto-start");
+            BroadcastLoginStatus(null);
+            BroadcastTunnelStatus(false, null);
+            return;
+        }
+
+        // 2. Check login
+        var login = await client.GetLoginStatusAsync(ct);
+        IsLoggedIn = login.IsLoggedIn;
+
+        BroadcastLoginStatus(login);
+
+        if (!login.IsLoggedIn)
+        {
+            logger?.LogInformation("[DevTunnels] Not logged in; tunnel will start on demand when a webhook integration is enabled");
+            BroadcastTunnelStatus(false, null);
+            return;
+        }
+
+        // Tunnel is intentionally not started here. Webhook integrations (e.g. KoFiService)
+        // call StartTunnelAsync on demand when they determine they have a configured token.
+        // This avoids opening a public tunnel when no integration actually requires it.
+        logger?.LogInformation("[DevTunnels] CLI ready and logged in; tunnel will start on demand");
+        BroadcastTunnelStatus(false, null);
+    }
+
+    public async Task StopAsync(CancellationToken ct = default)
+    {
+        await StopTunnelAsync();
+
+        IsCliInstalled = false;
+        IsLoggedIn = false;
+
+        BroadcastCliStatus(null);
+        BroadcastLoginStatus(null);
+        BroadcastTunnelStatus(false, null);
+    }
+
+    // Interactive actions called from the UI
+
+    public async Task<DevTunnelCliProbeResult> RefreshCliStatusAsync(CancellationToken ct = default)
+    {
+        var probe = await client.ProbeCliAsync(ct);
+        IsCliInstalled = probe.IsInstalled;
+        BroadcastCliStatus(probe);
+        return probe;
+    }
+
+    public async Task<DevTunnelLoginStatus> LoginAsync(LoginProvider provider, CancellationToken ct = default)
+    {
+        var status = await client.LoginAsync(provider, ct);
+        IsLoggedIn = status.IsLoggedIn;
+        BroadcastLoginStatus(status);
+        return status;
+    }
+
+    public async Task<DevTunnelLoginStatus> LogoutAsync(CancellationToken ct = default)
+    {
+        await StopTunnelAsync();
+        await client.LogoutAsync(ct);
+        IsLoggedIn = false;
+        BroadcastLoginStatus(null);
+        BroadcastTunnelStatus(false, null);
+        return new DevTunnelLoginStatus { Status = "Logged out" };
+    }
+
+    public async Task StartTunnelAsync(CancellationToken ct = default)
+    {
+        // Fast path: no lock needed if a session is already running.
+        if (_session != null) return;
+
+        await _startLock.WaitAsync(ct);
+        try
+        {
+            // Re-check under the lock in case another caller just finished starting.
+            if (_session != null) return;
+
+            BroadcastTunnelStatus(false, null, starting: true);
+
+            var serverPort = int.TryParse(config.Get("Server", "Port", "14040"), out var p) ? p : 14040;
+            var tunnelId = config.Get(_configSection, "TunnelId", string.Empty);
+
+            // The Azure DevTunnels CLI internally assigns a random tunnel ID that may not match
+            // the short-name format required by StartHostSessionAsync validation. We always use
+            // the label (name) we chose as the persistent ID; the CLI accepts it as a host arg.
+            // Also clear any cluster-qualified IDs persisted by older code (e.g. "name.abc.usw2").
+            if (!string.IsNullOrWhiteSpace(tunnelId) && !DevTunnelValidation.IsValidTunnelId(tunnelId))
+            {
+                logger?.LogInformation("[DevTunnels] Stored tunnel ID is not in short-name format; resetting");
+                tunnelId = string.Empty;
+                config.Set(_configSection, "TunnelId", string.Empty);
+                config.Save();
+            }
+
+            if (string.IsNullOrWhiteSpace(tunnelId))
+            {
+                tunnelId = $"subathon-{serverPort}";
+                config.Set(_configSection, "TunnelId", tunnelId);
+                config.Save();
+            }
+
+            // Always ensure the tunnel and port exist before hosting (idempotent operations).
+            // The port must be pre-registered on the tunnel; passing PortNumber to StartHostSessionAsync
+            // is for ephemeral tunnels only and causes a service-side error on named persistent tunnels.
+            logger?.LogInformation("[DevTunnels] Ensuring tunnel '{Id}' and port {Port} exist", tunnelId, serverPort);
+            await client.CreateOrUpdateTunnelAsync(
+                tunnelId,
+                new DevTunnelOptions { AllowAnonymous = true, Description = "SubathonManager webhook tunnel" },
+                ct);
+            await client.CreateOrReplacePortAsync(
+                tunnelId,
+                serverPort,
+                new DevTunnelPortOptions { Protocol = "http", AllowAnonymous = true },
+                ct);
+
+            logger?.LogInformation("[DevTunnels] Starting host session for tunnel '{Id}'", tunnelId);
+
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            _session = await client.StartHostSessionAsync(
+                new DevTunnelHostStartOptions { TunnelId = tunnelId, ReadyTimeout = TimeSpan.FromSeconds(30) },
+                _cts.Token);
+
+            await _session.WaitForReadyAsync(_cts.Token);
+
+            PublicBaseUrl = _session.PublicUrl?.ToString()?.TrimEnd('/');
+            IsTunnelRunning = true;
+
+            logger?.LogInformation("[DevTunnels] Tunnel running at {Url}", PublicBaseUrl);
+            BroadcastTunnelStatus(true, PublicBaseUrl);
+
+            // Monitor for unexpected exit in the background
+            _ = MonitorSessionAsync(_cts.Token);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "[DevTunnels] Failed to start tunnel");
+            await StopTunnelAsync();
+            BroadcastTunnelStatus(false, null);
+        }
+        finally
+        {
+            _startLock.Release();
+        }
+    }
+
+    public async Task StopTunnelAsync()
+    {
+        PublicBaseUrl = null;
+        IsTunnelRunning = false;
+
+        if (_session != null)
+        {
+            try { await _session.StopAsync(); } catch { /**/ }
+            await _session.DisposeAsync();
+            _session = null;
+        }
+
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+
+        BroadcastTunnelStatus(false, null);
+    }
+
+    // Helpers
+
+    private async Task MonitorSessionAsync(CancellationToken ct)
+    {
+        try
+        {
+            if (_session == null) return;
+            await _session.WaitForExitAsync(ct);
+
+            if (!ct.IsCancellationRequested && IsTunnelRunning)
+            {
+                logger?.LogWarning("[DevTunnels] Host session exited unexpectedly: {Reason}", _session.FailureReason);
+                await StopTunnelAsync();
+                BroadcastTunnelStatus(false, null);
+            }
+        }
+        catch (OperationCanceledException) { /**/ }
+    }
+
+    private void BroadcastCliStatus(DevTunnelCliProbeResult? probe)
+    {
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Source = SubathonEventSource.DevTunnels,
+            Service = "Cli",
+            Name = probe?.IsInstalled == true ? probe.Version?.ToString() ?? "" : "",
+            Status = probe?.IsInstalled ?? false
+        });
+    }
+
+    private void BroadcastLoginStatus(DevTunnelLoginStatus? login)
+    {
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Source = SubathonEventSource.DevTunnels,
+            Service = "Login",
+            Name = login?.Username ?? "",
+            Status = login?.IsLoggedIn ?? false
+        });
+    }
+
+    private void BroadcastTunnelStatus(bool running, string? url, bool starting = false)
+    {
+        IsTunnelRunning = running;
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Source = SubathonEventSource.DevTunnels,
+            Service = "Tunnel",
+            Name = starting ? "(starting…)" : (url ?? ""),
+            Status = running
+        });
+    }
+
+    [ExcludeFromCodeCoverage]
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    [ExcludeFromCodeCoverage]
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+        _startLock.Dispose();
+        _disposed = true;
+    }
+}

--- a/SubathonManager.Integration/DevTunnelsService.cs
+++ b/SubathonManager.Integration/DevTunnelsService.cs
@@ -192,15 +192,16 @@ public class DevTunnelsService(
 
     public async Task StopTunnelAsync()
     {
+        if (_session == null) return;
+
+        BroadcastTunnelStatus(false, null, stopping: true);
+
         PublicBaseUrl = null;
         IsTunnelRunning = false;
 
-        if (_session != null)
-        {
-            try { await _session.StopAsync(); } catch { /**/ }
-            await _session.DisposeAsync();
-            _session = null;
-        }
+        try { await _session.StopAsync(); } catch { /**/ }
+        await _session.DisposeAsync();
+        _session = null;
 
         _cts?.Cancel();
         _cts?.Dispose();
@@ -250,14 +251,14 @@ public class DevTunnelsService(
         });
     }
 
-    private void BroadcastTunnelStatus(bool running, string? url, bool starting = false)
+    private void BroadcastTunnelStatus(bool running, string? url, bool starting = false, bool stopping = false)
     {
         IsTunnelRunning = running;
         IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
         {
             Source = SubathonEventSource.DevTunnels,
             Service = "Tunnel",
-            Name = starting ? "(starting…)" : (url ?? ""),
+            Name = starting ? "(starting…)" : stopping ? "(stopping…)" : (url ?? ""),
             Status = running
         });
     }

--- a/SubathonManager.Integration/DevTunnelsService.cs
+++ b/SubathonManager.Integration/DevTunnelsService.cs
@@ -199,16 +199,13 @@ public class DevTunnelsService(
         PublicBaseUrl = null;
         IsTunnelRunning = false;
 
-        // Kill(entireProcessTree:true) is synchronous and blocks until all Win32 API
-        // calls complete — offload to thread pool so the UI can render "Stopping…".
-        var session = _session;
-        try { await Task.Run(async () => await session.StopAsync()); }
+        try { await _session.StopAsync(); }
         catch (Exception ex)
         {
             logger?.LogWarning(ex, "[DevTunnels] Failed to stop tunnel");
         }
-        await session.DisposeAsync();
-        if (ReferenceEquals(_session, session)) _session = null;
+        await _session.DisposeAsync();
+        _session = null;
 
         _cts?.Cancel();
         _cts?.Dispose();

--- a/SubathonManager.Integration/DevTunnelsService.cs
+++ b/SubathonManager.Integration/DevTunnelsService.cs
@@ -199,9 +199,16 @@ public class DevTunnelsService(
         PublicBaseUrl = null;
         IsTunnelRunning = false;
 
-        try { await _session.StopAsync(); } catch { /**/ }
-        await _session.DisposeAsync();
-        _session = null;
+        // Kill(entireProcessTree:true) is synchronous and blocks until all Win32 API
+        // calls complete — offload to thread pool so the UI can render "Stopping…".
+        var session = _session;
+        try { await Task.Run(async () => await session.StopAsync()); }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "[DevTunnels] Failed to stop tunnel");
+        }
+        await session.DisposeAsync();
+        if (ReferenceEquals(_session, session)) _session = null;
 
         _cts?.Cancel();
         _cts?.Dispose();

--- a/SubathonManager.Integration/KoFiService.cs
+++ b/SubathonManager.Integration/KoFiService.cs
@@ -84,10 +84,12 @@ public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClie
             ? tunnelBaseUrl.TrimEnd('/') + WebhookPath
             : null;
 
+        // Only report as connected when both the token is configured and the tunnel
+        // is actually up with a public URL. A token alone means nothing without reachability.
         IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
         {
             Name = fullUrl ?? "",
-            Status = enabled,
+            Status = enabled && fullUrl != null,
             Source = SubathonEventSource.KoFiWebhook,
             Service = nameof(SubathonEventSource.KoFiWebhook)
         });

--- a/SubathonManager.Integration/KoFiService.cs
+++ b/SubathonManager.Integration/KoFiService.cs
@@ -190,6 +190,16 @@ public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClie
                     Currency = shop.Currency ?? "USD",
                     EventTimestamp = shop.Timestamp.LocalDateTime,
                 },
+                KoFiCommissionEvent comm => new SubathonEvent
+                {
+                    Id = TryParseGuid(comm.MessageId),
+                    Source = SubathonEventSource.KoFiWebhook,
+                    EventType = SubathonEventType.KoFiCommissionOrder,
+                    User = comm.FromName ?? "Ko-fi Supporter",
+                    Value = comm.Amount.ToString("F2", System.Globalization.CultureInfo.InvariantCulture),
+                    Currency = comm.Currency ?? "USD",
+                    EventTimestamp = comm.Timestamp.LocalDateTime,
+                },
                 _ => null
             };
         }

--- a/SubathonManager.Integration/KoFiService.cs
+++ b/SubathonManager.Integration/KoFiService.cs
@@ -180,6 +180,16 @@ public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClie
                     Currency = "member",
                     EventTimestamp = r.Timestamp.LocalDateTime,
                 },
+                KoFiShopOrderEvent shop => new SubathonEvent
+                {
+                    Id = TryParseGuid(shop.MessageId),
+                    Source = SubathonEventSource.KoFiWebhook,
+                    EventType = SubathonEventType.KoFiShopOrder,
+                    User = shop.FromName ?? "Ko-fi Supporter",
+                    Value = shop.Amount.ToString("F2", System.Globalization.CultureInfo.InvariantCulture),
+                    Currency = shop.Currency ?? "USD",
+                    EventTimestamp = shop.Timestamp.LocalDateTime,
+                },
                 _ => null
             };
         }

--- a/SubathonManager.Integration/KoFiService.cs
+++ b/SubathonManager.Integration/KoFiService.cs
@@ -1,0 +1,251 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Agash.Webhook.Abstractions;
+using KoFi.Client.Events;
+using KoFi.Client.Options;
+using KoFi.Client.Webhooks;
+using Microsoft.Extensions.Logging;
+using SubathonManager.Core;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Models;
+using SubathonManager.Core.Objects;
+
+namespace SubathonManager.Integration;
+
+public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClientFactory httpClientFactory, DevTunnelsService devTunnels)
+    : IWebhookIntegration
+{
+    private readonly string _configSection = "KoFi";
+
+    // Headers forwarded verbatim to any configured forward URLs.
+    // Hop-by-hop and transport headers are excluded; they don't apply end-to-end.
+    private static readonly HashSet<string> _skipForwardHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "host", "connection", "transfer-encoding", "keep-alive",
+        "proxy-authenticate", "proxy-authorization", "te", "trailer", "upgrade"
+    };
+
+    public string WebhookPath => "/api/webhooks/kofi";
+
+    private readonly KoFiWebhookHandler _handler = new();
+
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        IntegrationEvents.ConnectionUpdated += OnTunnelUpdated;
+
+        var token = config.GetFromEncoded(_configSection, "VerificationToken", string.Empty);
+        bool enabled = !string.IsNullOrWhiteSpace(token);
+
+        if (enabled)
+        {
+            logger?.LogInformation("[Ko-fi] Webhook listener ready at {Path}", WebhookPath);
+            // Start tunnel on demand; no need to open a public endpoint if no token is set.
+            // Fire-and-forget: OnTunnelUpdated will broadcast the composed URL once ready.
+            _ = devTunnels.StartTunnelAsync(ct);
+        }
+        else
+        {
+            logger?.LogInformation("[Ko-fi] No verification token configured; Ko-fi integration is disabled");
+        }
+
+        // Seed status; include public URL if the tunnel is already running
+        var tunnelConn = Utils.GetConnection(SubathonEventSource.DevTunnels, "Tunnel");
+        BroadcastStatus(enabled, tunnelConn.Status ? tunnelConn.Name : null);
+
+        await Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken ct = default)
+    {
+        IntegrationEvents.ConnectionUpdated -= OnTunnelUpdated;
+        BroadcastStatus(false, null);
+        return Task.CompletedTask;
+    }
+
+    // Re-broadcast our own status whenever the shared tunnel changes so consumers
+    // (e.g. KoFiWebhookSettings) always see the composed public URL without having
+    // to know about DevTunnels or manually concatenate paths.
+    private void OnTunnelUpdated(IntegrationConnection connection)
+    {
+        if (connection is not { Source: SubathonEventSource.DevTunnels, Service: "Tunnel" }) return;
+        var token = config.GetFromEncoded(_configSection, "VerificationToken", string.Empty);
+        bool enabled = !string.IsNullOrWhiteSpace(token);
+        BroadcastStatus(enabled, connection.Status ? connection.Name : null);
+    }
+
+    private void BroadcastStatus(bool enabled, string? tunnelBaseUrl)
+    {
+        // Compose the full public URL from the tunnel base + our own path.
+        // WebhookPath is the single source of truth for the path segment.
+        string? fullUrl = !string.IsNullOrWhiteSpace(tunnelBaseUrl) && tunnelBaseUrl != "(starting…)"
+            ? tunnelBaseUrl.TrimEnd('/') + WebhookPath
+            : null;
+
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Name = fullUrl ?? "",
+            Status = enabled,
+            Source = SubathonEventSource.KoFiWebhook,
+            Service = nameof(SubathonEventSource.KoFiWebhook)
+        });
+
+        if (fullUrl != null)
+            logger?.LogInformation("[Ko-fi] Public webhook URL: {Url}", fullUrl);
+    }
+
+    public async Task HandleWebhookAsync(byte[] rawBody, IReadOnlyDictionary<string, string> headers, CancellationToken ct = default)
+    {
+        // Forward the raw request to any configured URLs before verifying; the
+        // forwarded service (e.g. StreamerBot) needs the same unmodified payload.
+        await ForwardRequestAsync(rawBody, headers, ct);
+
+        var token = config.GetFromEncoded(_configSection, "VerificationToken", string.Empty);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            logger?.LogWarning("[Ko-fi] Received webhook but no verification token is configured");
+            return;
+        }
+
+        // Ko-fi always sends application/x-www-form-urlencoded; use the inbound
+        // Content-Type if present, fall back to the known Ko-fi value.
+        var contentType = headers.TryGetValue("Content-Type", out var ct2) ? ct2
+            : "application/x-www-form-urlencoded";
+
+        var request = new WebhookRequest
+        {
+            Method = "POST",
+            Path = WebhookPath,
+            Body = rawBody,
+            ContentType = contentType
+        };
+
+        var result = await _handler.HandleAsync(request, new KoFiWebhookOptions { VerificationToken = token }, ct);
+
+        if (!result.IsAuthenticated)
+        {
+            logger?.LogWarning("[Ko-fi] Webhook authentication failed: {Reason}", result.FailureReason);
+            return;
+        }
+
+        if (!result.IsKnownEvent || result.Event is null)
+        {
+            logger?.LogDebug("[Ko-fi] Received unknown/unsupported Ko-fi event type");
+            return;
+        }
+
+        var ev = MapToSubathonEvent(result.Event);
+        if (ev != null)
+        {
+            SubathonEvents.RaiseSubathonEventCreated(ev);
+            logger?.LogDebug("[Ko-fi] Raised {EventType} from {User}", ev.EventType, ev.User);
+        }
+    }
+
+    private SubathonEvent? MapToSubathonEvent(KoFiWebhookEvent koFiEvent)
+    {
+        try
+        {
+            return koFiEvent switch
+            {
+                KoFiDonationEvent d => new SubathonEvent
+                {
+                    Id = TryParseGuid(d.MessageId),
+                    Source = SubathonEventSource.KoFiWebhook,
+                    EventType = SubathonEventType.KoFiDonation,
+                    User = d.FromName ?? "Ko-fi Supporter",
+                    Value = d.Amount.ToString("F2", System.Globalization.CultureInfo.InvariantCulture),
+                    Currency = d.Currency ?? "USD",
+                    EventTimestamp = d.Timestamp.LocalDateTime,
+                },
+                KoFiSubscriptionStartedEvent s => new SubathonEvent
+                {
+                    Id = TryParseGuid(s.MessageId),
+                    Source = SubathonEventSource.KoFiWebhook,
+                    EventType = SubathonEventType.KoFiSub,
+                    User = s.FromName ?? "Ko-fi Supporter",
+                    Value = s.TierName ?? "1000",
+                    Currency = "member",
+                    EventTimestamp = s.Timestamp.LocalDateTime,
+                },
+                KoFiSubscriptionRenewedEvent r => new SubathonEvent
+                {
+                    Id = TryParseGuid(r.MessageId),
+                    Source = SubathonEventSource.KoFiWebhook,
+                    EventType = SubathonEventType.KoFiSub,
+                    User = r.FromName ?? "Ko-fi Supporter",
+                    Value = r.TierName ?? "1000",
+                    Currency = "member",
+                    EventTimestamp = r.Timestamp.LocalDateTime,
+                },
+                _ => null
+            };
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "[Ko-fi] Failed to map Ko-fi event to SubathonEvent");
+            return null;
+        }
+    }
+
+    private async Task ForwardRequestAsync(byte[] rawBody, IReadOnlyDictionary<string, string> headers, CancellationToken ct)
+    {
+        string? forwardUrlsRaw = config.Get(_configSection, "ForwardUrls", string.Empty);
+        if (string.IsNullOrWhiteSpace(forwardUrlsRaw)) return;
+
+        var urls = forwardUrlsRaw
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var client = httpClientFactory.CreateClient(nameof(KoFiService));
+
+        foreach (var url in urls)
+        {
+            try
+            {
+                using var content = new ByteArrayContent(rawBody);
+
+                // Forward all inbound headers except hop-by-hop ones.
+                // Content-Type is applied to the content itself; everything else goes on the request.
+                foreach (var (key, value) in headers)
+                {
+                    if (_skipForwardHeaders.Contains(key)) continue;
+
+                    if (key.Equals("Content-Type", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (MediaTypeHeaderValue.TryParse(value, out var mt))
+                            content.Headers.ContentType = mt;
+                    }
+                    else if (key.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // HttpClient sets this automatically from ByteArrayContent
+                    }
+                    else
+                    {
+                        content.Headers.TryAddWithoutValidation(key, value);
+                    }
+                }
+
+                // Ensure Content-Type is set even if the inbound request omitted it
+                content.Headers.ContentType ??= new MediaTypeHeaderValue("application/x-www-form-urlencoded")
+                {
+                    CharSet = Encoding.UTF8.WebName
+                };
+
+                var response = await client.PostAsync(url, content, ct);
+                logger?.LogDebug("[Ko-fi] Forwarded webhook to {Url}: {Status}", url, response.StatusCode);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "[Ko-fi] Failed to forward webhook to {Url}", url);
+            }
+        }
+    }
+
+    private static Guid TryParseGuid(string? value)
+    {
+        if (value != null && Guid.TryParse(value, out var g)) return g;
+        return Utils.CreateGuidFromUniqueString(value ?? Guid.NewGuid().ToString());
+    }
+}

--- a/SubathonManager.Integration/SubathonManager.Integration.csproj
+++ b/SubathonManager.Integration/SubathonManager.Integration.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
       <PackageReference Include="Agash.Webhook.Abstractions" Version="1.0.1" />
-      <PackageReference Include="DevTunnels.Client.DependencyInjection" Version="1.0.1" />
+      <PackageReference Include="DevTunnels.Client.DependencyInjection" Version="1.0.4" />
       <PackageReference Include="KoFi.Client" Version="0.1.1-dev1" />
       <PackageReference Include="Agash.YTLiveChat" Version="4.2.0-dev3" />
       <PackageReference Include="GoAffPro.Client" Version="0.4.0" />

--- a/SubathonManager.Integration/SubathonManager.Integration.csproj
+++ b/SubathonManager.Integration/SubathonManager.Integration.csproj
@@ -10,6 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Agash.Webhook.Abstractions" Version="1.0.1" />
+      <PackageReference Include="DevTunnels.Client.DependencyInjection" Version="1.0.1" />
+      <PackageReference Include="KoFi.Client" Version="0.1.1-dev1" />
       <PackageReference Include="Agash.YTLiveChat" Version="4.2.0-dev3" />
       <PackageReference Include="GoAffPro.Client" Version="0.4.0" />
       <PackageReference Include="StreamElements.WebSocket" Version="1.0.2" />

--- a/SubathonManager.Server/HttpListenerContextAdapter.cs
+++ b/SubathonManager.Server/HttpListenerContextAdapter.cs
@@ -21,6 +21,21 @@ public sealed class HttpListenerContextAdapter : IHttpContext
     public string QueryString => _ctx.Request.Url!.Query.TrimStart('?');
     public Encoding Encoding => _ctx.Request.ContentEncoding;
     public bool IsWebSocket => _ctx.Request.IsWebSocketRequest;
+
+    public IReadOnlyDictionary<string, string> Headers
+    {
+        get
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var headers = _ctx.Request.Headers;
+            foreach (string? key in headers.AllKeys)
+            {
+                if (key != null)
+                    dict[key] = headers[key] ?? string.Empty;
+            }
+            return dict;
+        }
+    }
     
     public Task<WebSocket>? AcceptWebSocketAsync(string? subProtocol = null)
     {

--- a/SubathonManager.Server/Interfaces/IHttpContext.cs
+++ b/SubathonManager.Server/Interfaces/IHttpContext.cs
@@ -8,7 +8,9 @@ public interface IHttpContext
     string Path { get; }
     
     string QueryString { get; }
-    
+
+    IReadOnlyDictionary<string, string> Headers { get; }
+
     Stream Body { get; }
     Encoding Encoding { get; }
     bool IsWebSocket { get; }

--- a/SubathonManager.Server/TcpListenerContextAdapter.cs
+++ b/SubathonManager.Server/TcpListenerContextAdapter.cs
@@ -18,6 +18,7 @@ public sealed class TcpListenerContextAdapter : IHttpContext
     public string Method { get; }
     public string Path { get; }
     public string QueryString { get; }
+    public IReadOnlyDictionary<string, string> Headers => _headers;
     public Encoding Encoding => Encoding.UTF8;
     public Stream Body { get; }
 

--- a/SubathonManager.Server/WebServer.Webhooks.cs
+++ b/SubathonManager.Server/WebServer.Webhooks.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SubathonManager.Core;
+using SubathonManager.Core.Interfaces;
+
+namespace SubathonManager.Server;
+
+public partial class WebServer
+{
+    private void SetupWebhookRoutes()
+    {
+        foreach (var integration in AppServices.Provider.GetServices<IWebhookIntegration>())
+            RegisterWebhookRoute(integration);
+    }
+
+    private void RegisterWebhookRoute(IWebhookIntegration integration)
+    {
+        var captured = integration;
+        _routes.Add((new RouteKey("POST", captured.WebhookPath), async ctx =>
+        {
+            var headers = ctx.Headers;
+            using var ms = new MemoryStream();
+            await ctx.Body.CopyToAsync(ms);
+            byte[] rawBody = ms.ToArray();
+            await ctx.WriteResponse(200, "OK");
+            await captured.HandleWebhookAsync(rawBody, headers);
+        }));
+        _logger?.LogDebug("Registered webhook route: POST {Path}", captured.WebhookPath);
+    }
+}

--- a/SubathonManager.Server/WebServer.cs
+++ b/SubathonManager.Server/WebServer.cs
@@ -77,6 +77,7 @@ public partial class WebServer : IAppService
         
         _routes.Clear();
         SetupApiRoutes();
+        SetupWebhookRoutes();
         SetupOverlayRoutes();
         SetupWebsocketListeners();
 

--- a/SubathonManager.Tests/IntegrationUnitTests/DevTunnelsServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/DevTunnelsServiceTests.cs
@@ -1,0 +1,256 @@
+using System.Reflection;
+using DevTunnels.Client;
+using DevTunnels.Client.Authentication;
+using DevTunnels.Client.Hosting;
+using DevTunnels.Client.Ports;
+using DevTunnels.Client.Tunnels;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Objects;
+using SubathonManager.Integration;
+using SubathonManager.Tests.Utility;
+
+namespace SubathonManager.Tests.IntegrationUnitTests;
+
+[Collection("SharedEventBusTests")]
+public class DevTunnelsServiceTests
+{
+    public DevTunnelsServiceTests()
+    {
+        typeof(IntegrationEvents)
+            .GetField("ConnectionUpdated", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+    }
+
+    private static (DevTunnelsService service, Mock<IDevTunnelsClient> mockClient) MakeService(
+        Dictionary<(string, string), string>? configValues = null)
+    {
+        var logger = new Mock<ILogger<DevTunnelsService>>();
+        var mockClient = new Mock<IDevTunnelsClient>();
+        IConfig config = MockConfig.MakeMockConfig(configValues ?? new Dictionary<(string, string), string>
+        {
+            { ("Server", "Port"), "14040" },
+        });
+        return (new DevTunnelsService(logger.Object, config, mockClient.Object), mockClient);
+    }
+
+    private static Mock<IDevTunnelHostSession> MakeSession(string publicUrl = "https://test.devtunnels.ms")
+    {
+        var mockSession = new Mock<IDevTunnelHostSession>();
+        _ = mockSession.Setup(s => s.PublicUrl).Returns(new Uri(publicUrl));
+        _ = mockSession.Setup(s => s.WaitForReadyAsync(It.IsAny<CancellationToken>())).Returns(ValueTask.CompletedTask);
+        _ = mockSession.Setup(s => s.WaitForExitAsync(It.IsAny<CancellationToken>()))
+            .Returns<CancellationToken>(async ct => await Task.Delay(Timeout.Infinite, ct));
+        _ = mockSession.Setup(s => s.StopAsync(It.IsAny<CancellationToken>())).Returns(ValueTask.CompletedTask);
+        _ = mockSession.As<IAsyncDisposable>().Setup(s => s.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        return mockSession;
+    }
+
+    private static void SetupStartTunnel(Mock<IDevTunnelsClient> mockClient, IDevTunnelHostSession session)
+    {
+        mockClient.Setup(c => c.CreateOrUpdateTunnelAsync(It.IsAny<string>(), It.IsAny<DevTunnelOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<DevTunnelStatus>(new DevTunnelStatus()));
+        mockClient.Setup(c => c.CreateOrReplacePortAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DevTunnelPortOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<DevTunnelPortStatus>(new DevTunnelPortStatus()));
+        _ = mockClient.Setup(c => c.StartHostSessionAsync(It.IsAny<DevTunnelHostStartOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<IDevTunnelHostSession>(session));
+    }
+
+    [Fact]
+    public async Task StartAsync_CliNotInstalled_BroadcastsCliOffline()
+    {
+        (DevTunnelsService? service, Mock<IDevTunnelsClient>? mockClient) = MakeService();
+        _ = mockClient.Setup(c => c.ProbeCliAsync(It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<DevTunnelCliProbeResult>(
+                new DevTunnelCliProbeResult(false, null, null, "not found", false, "CLI not found")));
+
+        bool? lastTunnelStatus = null;
+        void Handler(IntegrationConnection conn)
+        {
+            if (conn.Source == SubathonEventSource.DevTunnels && conn.Service == "Tunnel")
+            {
+                lastTunnelStatus = conn.Status;
+            }
+        }
+
+        IntegrationEvents.ConnectionUpdated += Handler;
+        try
+        {
+            await service.StartAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            IntegrationEvents.ConnectionUpdated -= Handler;
+        }
+
+        Assert.False(service.IsCliInstalled);
+        Assert.False(service.IsLoggedIn);
+        Assert.False(service.IsTunnelRunning);
+        Assert.False(lastTunnelStatus);
+        mockClient.Verify(c => c.GetLoginStatusAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_CliInstalledButNotLoggedIn_DoesNotStartTunnel()
+    {
+        (DevTunnelsService? service, Mock<IDevTunnelsClient>? mockClient) = MakeService();
+        _ = mockClient.Setup(c => c.ProbeCliAsync(It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<DevTunnelCliProbeResult>(
+                new DevTunnelCliProbeResult(true, "devtunnel", new Version(1, 0), "v1.0", true, null)));
+        _ = mockClient.Setup(c => c.GetLoginStatusAsync(It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<DevTunnelLoginStatus>(new DevTunnelLoginStatus { Status = "Logged out" }));
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(service.IsCliInstalled);
+        Assert.False(service.IsLoggedIn);
+        Assert.False(service.IsTunnelRunning);
+        mockClient.Verify(c => c.StartHostSessionAsync(It.IsAny<DevTunnelHostStartOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_CliInstalledAndLoggedIn_DoesNotAutoStartTunnel()
+    {
+        (DevTunnelsService? service, Mock<IDevTunnelsClient>? mockClient) = MakeService();
+        _ = mockClient.Setup(c => c.ProbeCliAsync(It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<DevTunnelCliProbeResult>(
+                new DevTunnelCliProbeResult(true, "devtunnel", new Version(1, 0), "v1.0", true, null)));
+        _ = mockClient.Setup(c => c.GetLoginStatusAsync(It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<DevTunnelLoginStatus>(new DevTunnelLoginStatus { Status = "Logged in", Username = "user@example.com" }));
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(service.IsCliInstalled);
+        Assert.True(service.IsLoggedIn);
+        Assert.False(service.IsTunnelRunning);
+        mockClient.Verify(c => c.StartHostSessionAsync(It.IsAny<DevTunnelHostStartOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartTunnelAsync_StartsSessionAndBroadcastsPublicUrl()
+    {
+        (DevTunnelsService? service, Mock<IDevTunnelsClient>? mockClient) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("Server", "Port"), "14040" },
+            { ("DevTunnels", "TunnelId"), "my-tunnel" },
+        });
+
+        Mock<IDevTunnelHostSession> mockSession = MakeSession("https://my-tunnel.devtunnels.ms");
+        SetupStartTunnel(mockClient, mockSession.Object);
+
+        string? broadcastedUrl = null;
+        void Handler(IntegrationConnection conn)
+        {
+            if (conn.Source == SubathonEventSource.DevTunnels && conn.Service == "Tunnel" && conn.Status)
+            {
+                broadcastedUrl = conn.Name;
+            }
+        }
+
+        IntegrationEvents.ConnectionUpdated += Handler;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        try
+        {
+            await service.StartTunnelAsync(cts.Token);
+        }
+        finally
+        {
+            IntegrationEvents.ConnectionUpdated -= Handler;
+        }
+
+        Assert.True(service.IsTunnelRunning);
+        Assert.Equal("https://my-tunnel.devtunnels.ms", service.PublicBaseUrl);
+        Assert.Equal("https://my-tunnel.devtunnels.ms", broadcastedUrl);
+
+        await service.StopTunnelAsync();
+    }
+
+    [Fact]
+    public async Task StartTunnelAsync_WhenAlreadyRunning_IsIdempotent()
+    {
+        (DevTunnelsService? service, Mock<IDevTunnelsClient>? mockClient) = MakeService();
+        Mock<IDevTunnelHostSession> mockSession = MakeSession();
+        SetupStartTunnel(mockClient, mockSession.Object);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StartTunnelAsync(cts.Token);
+        await service.StartTunnelAsync(cts.Token);
+
+        mockClient.Verify(c => c.StartHostSessionAsync(It.IsAny<DevTunnelHostStartOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        await service.StopTunnelAsync();
+    }
+
+    [Fact]
+    public async Task StartTunnelAsync_InvalidStoredTunnelId_ResetsToGeneratedId()
+    {
+        (DevTunnelsService? service, Mock<IDevTunnelsClient>? mockClient) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("Server", "Port"), "14040" },
+            { ("DevTunnels", "TunnelId"), "bad.cluster.qualified.id" },
+        });
+
+        Mock<IDevTunnelHostSession> mockSession = MakeSession();
+        SetupStartTunnel(mockClient, mockSession.Object);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StartTunnelAsync(cts.Token);
+
+        mockClient.Verify(c => c.CreateOrUpdateTunnelAsync(
+            It.Is<string>(id => id.StartsWith("subathon-")),
+            It.IsAny<DevTunnelOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        await service.StopTunnelAsync();
+    }
+
+    [Fact]
+    public async Task StopTunnelAsync_WithRunningSession_StopsSessionAndClearsState()
+    {
+        (DevTunnelsService? service, Mock<IDevTunnelsClient>? mockClient) = MakeService();
+        Mock<IDevTunnelHostSession> mockSession = MakeSession();
+        SetupStartTunnel(mockClient, mockSession.Object);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await service.StartTunnelAsync(cts.Token);
+        Assert.True(service.IsTunnelRunning);
+
+        await service.StopTunnelAsync();
+
+        Assert.False(service.IsTunnelRunning);
+        Assert.Null(service.PublicBaseUrl);
+        mockSession.Verify(s => s.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StopAsync_ResetsStateAndBroadcastsDisabled()
+    {
+        (DevTunnelsService? service, Mock<IDevTunnelsClient> _) = MakeService();
+
+        bool? lastTunnelStatus = null;
+        void Handler(IntegrationConnection conn)
+        {
+            if (conn.Source == SubathonEventSource.DevTunnels && conn.Service == "Tunnel")
+            {
+                lastTunnelStatus = conn.Status;
+            }
+        }
+
+        IntegrationEvents.ConnectionUpdated += Handler;
+        try
+        {
+            await service.StopAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            IntegrationEvents.ConnectionUpdated -= Handler;
+        }
+
+        Assert.False(service.IsCliInstalled);
+        Assert.False(service.IsLoggedIn);
+        Assert.False(service.IsTunnelRunning);
+        Assert.False(lastTunnelStatus);
+    }
+}

--- a/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
@@ -114,8 +114,10 @@ public class KoFiServiceTests
     }
 
     [Fact]
-    public async Task StartAsync_WithToken_BroadcastsEnabled()
+    public async Task StartAsync_WithToken_NoTunnel_BroadcastsDisconnected()
     {
+        // Token configured but no tunnel running — status must be false until the
+        // tunnel is actually up and we have a reachable public URL.
         (KoFiService? service, DevTunnelsService _) = MakeService(new Dictionary<(string, string), string>
         {
             { ("KoFi", "VerificationToken"), "my-token" },
@@ -140,7 +142,7 @@ public class KoFiServiceTests
             IntegrationEvents.ConnectionUpdated -= Handler;
         }
 
-        Assert.True(status);
+        Assert.False(status);
         await service.StopAsync(TestContext.Current.CancellationToken);
     }
 

--- a/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
@@ -295,6 +295,38 @@ public class KoFiServiceTests
     }
 
     [Fact]
+    public async Task HandleWebhookAsync_ValidShopOrder_RaisesKoFiShopOrderEvent()
+    {
+        const string token = "test-token";
+        (KoFiService? service, DevTunnelsService _) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("KoFi", "VerificationToken"), token },
+        });
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        typeof(SubathonEvents)
+            .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+
+        byte[] body = BuildKoFiBody(token, "Shop Order", "Buyer", "25.00", "USD", Guid.NewGuid().ToString());
+
+        SubathonEvent? captured = null;
+        void EventHandler(SubathonEvent e) => captured = e;
+        SubathonEvents.SubathonEventCreated += EventHandler;
+        await service.HandleWebhookAsync(body, DefaultHeaders, TestContext.Current.CancellationToken);
+        SubathonEvents.SubathonEventCreated -= EventHandler;
+
+        Assert.NotNull(captured);
+        Assert.Equal(SubathonEventType.KoFiShopOrder, captured.EventType);
+        Assert.Equal(SubathonEventSource.KoFiWebhook, captured.Source);
+        Assert.Equal("Buyer", captured.User);
+        Assert.Equal("25.00", captured.Value);
+        Assert.Equal("USD", captured.Currency);
+
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task HandleWebhookAsync_ForwardsToConfiguredUrl()
     {
         const string token = "test-token";

--- a/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
@@ -1,0 +1,337 @@
+using System.Reflection;
+using System.Text;
+using System.Web;
+using DevTunnels.Client;
+using DevTunnels.Client.Tunnels;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Models;
+using SubathonManager.Core.Objects;
+using SubathonManager.Integration;
+using SubathonManager.Tests.Utility;
+
+namespace SubathonManager.Tests.IntegrationUnitTests;
+
+[Collection("SharedEventBusTests")]
+public class KoFiServiceTests
+{
+    public KoFiServiceTests()
+    {
+        typeof(IntegrationEvents)
+            .GetField("ConnectionUpdated", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+    }
+
+    private static (KoFiService service, DevTunnelsService devTunnels) MakeService(
+        Dictionary<(string, string), string>? configValues = null)
+    {
+        var logger = new Mock<ILogger<KoFiService>>();
+        var dtLogger = new Mock<ILogger<DevTunnelsService>>();
+        var mockClient = new Mock<IDevTunnelsClient>();
+
+        // Block CreateOrUpdateTunnelAsync so the fire-and-forget StartTunnelAsync
+        // call inside StartAsync does not race with test assertions.
+        mockClient.Setup(c => c.CreateOrUpdateTunnelAsync(
+                It.IsAny<string>(), It.IsAny<DevTunnelOptions>(), It.IsAny<CancellationToken>()))
+            .Returns<string, DevTunnelOptions, CancellationToken>(
+                async (_, _, ct) => { await Task.Delay(Timeout.Infinite, ct); return new DevTunnelStatus(); });
+
+        IConfig dtConfig = MockConfig.MakeMockConfig(new Dictionary<(string, string), string>
+        {
+            { ("Server", "Port"), "14040" },
+        });
+        var devTunnels = new DevTunnelsService(dtLogger.Object, dtConfig, mockClient.Object);
+
+        var httpFactory = new Mock<IHttpClientFactory>();
+        _ = httpFactory.Setup(f => f.CreateClient(nameof(KoFiService))).Returns(new HttpClient());
+
+        IConfig config = MockConfig.MakeMockConfig(configValues);
+        var koFi = new KoFiService(logger.Object, config, httpFactory.Object, devTunnels);
+        return (koFi, devTunnels);
+    }
+
+    private static byte[] BuildKoFiBody(string token, string type, string fromName,
+        string amount, string currency, string messageId,
+        bool isSubscriptionPayment = false, bool isFirstSubscriptionPayment = false,
+        string? tierName = null)
+    {
+        string json = $@"{{
+          ""verification_token"":""{token}"",
+          ""message_id"":""{messageId}"",
+          ""timestamp"":""2024-01-01T12:00:00+00:00"",
+          ""type"":""{type}"",
+          ""is_public"":true,
+          ""from_name"":""{fromName}"",
+          ""message"":""Test message"",
+          ""amount"":""{amount}"",
+          ""url"":""https://ko-fi.com/"",
+          ""email"":""test@test.com"",
+          ""currency"":""{currency}"",
+          ""is_subscription_payment"":{(isSubscriptionPayment ? "true" : "false")},
+          ""is_first_subscription_payment"":{(isFirstSubscriptionPayment ? "true" : "false")},
+          ""kofi_transaction_id"":""ABC123"",
+          ""shop_items"":null,
+          ""tier_name"":{(tierName != null ? $@"""{tierName}""" : "null")}
+        }}";
+
+        return Encoding.UTF8.GetBytes("data=" + HttpUtility.UrlEncode(json));
+    }
+
+    private static IReadOnlyDictionary<string, string> DefaultHeaders => new Dictionary<string, string>
+    {
+        { "Content-Type", "application/x-www-form-urlencoded" }
+    };
+
+    [Fact]
+    public async Task StartAsync_NoToken_BroadcastsDisabled()
+    {
+        (KoFiService? service, DevTunnelsService _) = MakeService();
+
+        bool? status = null;
+        void Handler(IntegrationConnection conn)
+        {
+            if (conn.Source == SubathonEventSource.KoFiWebhook)
+            {
+                status = conn.Status;
+            }
+        }
+
+        IntegrationEvents.ConnectionUpdated += Handler;
+        try
+        {
+            await service.StartAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            IntegrationEvents.ConnectionUpdated -= Handler;
+        }
+
+        Assert.False(status);
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task StartAsync_WithToken_BroadcastsEnabled()
+    {
+        (KoFiService? service, DevTunnelsService _) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("KoFi", "VerificationToken"), "my-token" },
+        });
+
+        bool? status = null;
+        void Handler(IntegrationConnection conn)
+        {
+            if (conn.Source == SubathonEventSource.KoFiWebhook)
+            {
+                status = conn.Status;
+            }
+        }
+
+        IntegrationEvents.ConnectionUpdated += Handler;
+        try
+        {
+            await service.StartAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            IntegrationEvents.ConnectionUpdated -= Handler;
+        }
+
+        Assert.True(status);
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task StopAsync_BroadcastsDisabled()
+    {
+        (KoFiService? service, DevTunnelsService _) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("KoFi", "VerificationToken"), "my-token" },
+        });
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        bool? status = null;
+        void Handler(IntegrationConnection conn)
+        {
+            if (conn.Source == SubathonEventSource.KoFiWebhook)
+            {
+                status = conn.Status;
+            }
+        }
+
+        IntegrationEvents.ConnectionUpdated += Handler;
+        try
+        {
+            await service.StopAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            IntegrationEvents.ConnectionUpdated -= Handler;
+        }
+
+        Assert.False(status);
+    }
+
+    [Fact]
+    public async Task HandleWebhookAsync_NoConfiguredToken_DoesNotRaiseEvent()
+    {
+        (KoFiService? service, DevTunnelsService _) = MakeService();
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        typeof(SubathonEvents)
+            .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+
+        byte[] body = BuildKoFiBody("any-token", "Donation", "Test User", "5.00", "USD", Guid.NewGuid().ToString());
+
+        SubathonEvent? captured = null;
+        void EventHandler(SubathonEvent e) => captured = e;
+        SubathonEvents.SubathonEventCreated += EventHandler;
+        await service.HandleWebhookAsync(body, DefaultHeaders, TestContext.Current.CancellationToken);
+        SubathonEvents.SubathonEventCreated -= EventHandler;
+
+        Assert.Null(captured);
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task HandleWebhookAsync_WrongToken_DoesNotRaiseEvent()
+    {
+        (KoFiService? service, DevTunnelsService _) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("KoFi", "VerificationToken"), "correct-token" },
+        });
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        typeof(SubathonEvents)
+            .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+
+        byte[] body = BuildKoFiBody("wrong-token", "Donation", "Test User", "5.00", "USD", Guid.NewGuid().ToString());
+
+        SubathonEvent? captured = null;
+        void EventHandler(SubathonEvent e) => captured = e;
+        SubathonEvents.SubathonEventCreated += EventHandler;
+        await service.HandleWebhookAsync(body, DefaultHeaders, TestContext.Current.CancellationToken);
+        SubathonEvents.SubathonEventCreated -= EventHandler;
+
+        Assert.Null(captured);
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task HandleWebhookAsync_ValidDonation_RaisesKoFiDonationEvent()
+    {
+        const string token = "test-token";
+        (KoFiService? service, DevTunnelsService _) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("KoFi", "VerificationToken"), token },
+        });
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        typeof(SubathonEvents)
+            .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+
+        byte[] body = BuildKoFiBody(token, "Donation", "Wolf", "10.00", "USD", Guid.NewGuid().ToString());
+
+        SubathonEvent? captured = null;
+        void EventHandler(SubathonEvent e) => captured = e;
+        SubathonEvents.SubathonEventCreated += EventHandler;
+        await service.HandleWebhookAsync(body, DefaultHeaders, TestContext.Current.CancellationToken);
+        SubathonEvents.SubathonEventCreated -= EventHandler;
+
+        Assert.NotNull(captured);
+        Assert.Equal(SubathonEventType.KoFiDonation, captured.EventType);
+        Assert.Equal(SubathonEventSource.KoFiWebhook, captured.Source);
+        Assert.Equal("Wolf", captured.User);
+        Assert.Equal("10.00", captured.Value);
+        Assert.Equal("USD", captured.Currency);
+
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Theory]
+    [InlineData(true, "Gold Tier")]
+    [InlineData(false, "Silver")]
+    public async Task HandleWebhookAsync_ValidSubscription_RaisesKoFiSubEvent(
+        bool isFirst, string tierName)
+    {
+        const string token = "test-token";
+        (KoFiService? service, DevTunnelsService _) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("KoFi", "VerificationToken"), token },
+        });
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        typeof(SubathonEvents)
+            .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+
+        byte[] body = BuildKoFiBody(token, "Subscription", "Supporter", "5.00", "USD",
+            Guid.NewGuid().ToString(),
+            isSubscriptionPayment: true,
+            isFirstSubscriptionPayment: isFirst,
+            tierName: tierName);
+
+        SubathonEvent? captured = null;
+        void EventHandler(SubathonEvent e) => captured = e;
+        SubathonEvents.SubathonEventCreated += EventHandler;
+        await service.HandleWebhookAsync(body, DefaultHeaders, TestContext.Current.CancellationToken);
+        SubathonEvents.SubathonEventCreated -= EventHandler;
+
+        Assert.NotNull(captured);
+        Assert.Equal(SubathonEventType.KoFiSub, captured.EventType);
+        Assert.Equal(SubathonEventSource.KoFiWebhook, captured.Source);
+        Assert.Equal("Supporter", captured.User);
+        Assert.Equal(tierName, captured.Value);
+        Assert.Equal("member", captured.Currency);
+
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task HandleWebhookAsync_ForwardsToConfiguredUrl()
+    {
+        const string token = "test-token";
+
+        await using MockWebServerHost mockServer = new MockWebServerHost().OnPost("/forward", "", statusCode: 200);
+
+        var logger = new Mock<ILogger<KoFiService>>();
+        var dtLogger = new Mock<ILogger<DevTunnelsService>>();
+        var mockClient = new Mock<IDevTunnelsClient>();
+        mockClient.Setup(c => c.CreateOrUpdateTunnelAsync(
+                It.IsAny<string>(), It.IsAny<DevTunnelOptions>(), It.IsAny<CancellationToken>()))
+            .Returns<string, DevTunnelOptions, CancellationToken>(
+                async (_, _, ct) => { await Task.Delay(Timeout.Infinite, ct); return new DevTunnelStatus(); });
+
+        IConfig dtConfig = MockConfig.MakeMockConfig(new Dictionary<(string, string), string>
+        {
+            { ("Server", "Port"), "14040" },
+        });
+        var devTunnels = new DevTunnelsService(dtLogger.Object, dtConfig, mockClient.Object);
+
+        var httpFactory = new Mock<IHttpClientFactory>();
+        _ = httpFactory.Setup(f => f.CreateClient(nameof(KoFiService))).Returns(new HttpClient());
+
+        IConfig config = MockConfig.MakeMockConfig(new Dictionary<(string, string), string>
+        {
+            { ("KoFi", "VerificationToken"), token },
+            { ("KoFi", "ForwardUrls"), mockServer.BaseUrl.TrimEnd('/') + "/forward" },
+        });
+        var service = new KoFiService(logger.Object, config, httpFactory.Object, devTunnels);
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        byte[] body = BuildKoFiBody(token, "Donation", "Test", "5.00", "USD", Guid.NewGuid().ToString());
+        await service.HandleWebhookAsync(body, DefaultHeaders, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, mockServer.PostCallCount);
+
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
@@ -327,6 +327,38 @@ public class KoFiServiceTests
     }
 
     [Fact]
+    public async Task HandleWebhookAsync_ValidCommission_RaisesKoFiCommissionEvent()
+    {
+        const string token = "test-token";
+        (KoFiService? service, DevTunnelsService _) = MakeService(new Dictionary<(string, string), string>
+        {
+            { ("KoFi", "VerificationToken"), token },
+        });
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        typeof(SubathonEvents)
+            .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
+            ?.SetValue(null, null);
+
+        byte[] body = BuildKoFiBody(token, "Commission", "Artist", "50.00", "USD", Guid.NewGuid().ToString());
+
+        SubathonEvent? captured = null;
+        void EventHandler(SubathonEvent e) => captured = e;
+        SubathonEvents.SubathonEventCreated += EventHandler;
+        await service.HandleWebhookAsync(body, DefaultHeaders, TestContext.Current.CancellationToken);
+        SubathonEvents.SubathonEventCreated -= EventHandler;
+
+        Assert.NotNull(captured);
+        Assert.Equal(SubathonEventType.KoFiCommissionOrder, captured.EventType);
+        Assert.Equal(SubathonEventSource.KoFiWebhook, captured.Source);
+        Assert.Equal("Artist", captured.User);
+        Assert.Equal("50.00", captured.Value);
+        Assert.Equal("USD", captured.Currency);
+
+        await service.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
     public async Task HandleWebhookAsync_ForwardsToConfiguredUrl()
     {
         const string token = "test-token";

--- a/SubathonManager.Tests/ServerUnitTests/MockHttpContext.cs
+++ b/SubathonManager.Tests/ServerUnitTests/MockHttpContext.cs
@@ -9,6 +9,7 @@ public class MockHttpContext: IHttpContext
     public string Method { get; set; } = "GET";
     public string Path { get; set; } = "/";
     public string QueryString { get; set; } = "";
+    public IReadOnlyDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     public Stream Body { get; set; } = new MemoryStream();
     public Encoding Encoding { get; set; } = Encoding.UTF8;
     public bool IsWebSocket { get; set; }

--- a/SubathonManager.UI/Services/ServiceManager.cs
+++ b/SubathonManager.UI/Services/ServiceManager.cs
@@ -40,6 +40,8 @@ public class ServiceManager(ILogger<ServiceManager> logger)
         await StartAsync<StreamElementsService>();
         await StartAsync<StreamLabsService>();
         await StartAsync<GoAffProService>();//(fireAndForget: true);
+        await StartAsync<DevTunnelsService>(); // shared tunnel infrastructure; must start before webhook integrations
+        await StartAsync<KoFiService>();
         await StartAsync<DiscordWebhookService>();
     }
 
@@ -51,6 +53,8 @@ public class ServiceManager(ILogger<ServiceManager> logger)
         await StopAsync<StreamElementsService>();
         await StopAsync<StreamLabsService>();
         await StopAsync<GoAffProService>();
+        await StopAsync<KoFiService>();
+        await StopAsync<DevTunnelsService>();
         await StopAsync<DiscordWebhookService>();
     }
 
@@ -124,9 +128,11 @@ public class ServiceManager(ILogger<ServiceManager> logger)
     // BlerpChatService
     // CommandService (Dependency for many)
     
-    public static EventService Events => Provider.GetRequiredService<EventService>(); 
+    public static EventService Events => Provider.GetRequiredService<EventService>();
     public static DiscordWebhookService DiscordWebhooks => Provider.GetRequiredService<DiscordWebhookService>();
     public static GoAffProService GoAffPro => Provider.GetRequiredService<GoAffProService>();
+    public static DevTunnelsService DevTunnels => Provider.GetRequiredService<DevTunnelsService>();
+    public static KoFiService KoFi => Provider.GetRequiredService<KoFiService>();
     public static TwitchService Twitch => Provider.GetRequiredService<TwitchService>(); 
     public static YouTubeService YouTube => Provider.GetRequiredService<YouTubeService>();
     public static PicartoService Picarto => Provider.GetRequiredService<PicartoService>();

--- a/SubathonManager.UI/Services/ServiceRegistration.cs
+++ b/SubathonManager.UI/Services/ServiceRegistration.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Net.Http;
+using DevTunnels.Client.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -46,7 +47,16 @@ public static class ServiceRegistration
         
         // Order Sales //
         services.AddSingleton<GoAffProService>();
-        
+
+        // Webhooks (shared tunnel infrastructure) //
+        services.AddDevTunnelsClient();
+        services.AddSingleton<DevTunnelsService>();
+
+        // Webhooks //
+        services.AddHttpClient(nameof(KoFiService)).SetHandlerLifetime(Timeout.InfiniteTimeSpan);
+        services.AddSingleton<KoFiService>();
+        services.AddSingleton<IWebhookIntegration>(sp => sp.GetRequiredService<KoFiService>());
+
         // Other //
         services.AddSingleton<DiscordWebhookService>();
     }

--- a/SubathonManager.UI/Views/SettingsViews/External/DevTunnelsSettings.xaml
+++ b/SubathonManager.UI/Views/SettingsViews/External/DevTunnelsSettings.xaml
@@ -1,0 +1,107 @@
+<views:SettingsControl x:Class="SubathonManager.UI.Views.SettingsViews.External.DevTunnelsSettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             xmlns:views="clr-namespace:SubathonManager.UI.Views">
+
+    <StackPanel>
+
+        <!-- Step 1: CLI -->
+        <TextBlock Text="Step 1: Install DevTunnels CLI" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,4"/>
+
+        <StackPanel Orientation="Horizontal" Margin="0,2,0,2">
+            <TextBlock Text="CLI Status:" Width="120" VerticalAlignment="Center"/>
+            <TextBlock x:Name="CliStatusText" Text="Unknown" VerticalAlignment="Center" FontSize="12" Margin="4,0,12,0"/>
+            <ui:Button x:Name="CheckCliBtn"
+                       Content="Check"
+                       Click="CheckCli_Click"
+                       Width="80" Height="30" Padding="4,2"
+                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+            <ui:Button x:Name="InstallCliBtn"
+                       Content="Get CLI"
+                       Click="GetCli_Click"
+                       Width="80" Height="30" Padding="4,2"
+                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                       Margin="6,0,0,0"
+                       ToolTip="Opens the Azure DevTunnels download page"/>
+        </StackPanel>
+
+        <TextBlock FontSize="11" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,2,0,8"
+                   Text="Install the Azure DevTunnels CLI from Microsoft. Once installed, click Check to confirm."/>
+
+        <Separator Margin="0,4,0,8"/>
+
+        <!-- Step 2: Login -->
+        <TextBlock Text="Step 2: Login" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,4"/>
+
+        <StackPanel Orientation="Horizontal" Margin="0,2,0,2">
+            <TextBlock Text="Login Status:" Width="120" VerticalAlignment="Center"/>
+            <TextBlock x:Name="LoginStatusText" Text="Not logged in" VerticalAlignment="Center" FontSize="12" Margin="4,0,12,0"/>
+        </StackPanel>
+
+        <StackPanel x:Name="LoginButtonsPanel" Orientation="Horizontal" Margin="0,4,0,2">
+            <ui:Button x:Name="LoginMicrosoftBtn"
+                       Content="Login with Microsoft"
+                       Click="LoginMicrosoft_Click"
+                       Width="170" Height="30" Padding="4,2"
+                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+            <ui:Button x:Name="LoginGithubBtn"
+                       Content="Login with GitHub"
+                       Click="LoginGitHub_Click"
+                       Width="150" Height="30" Padding="4,2"
+                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                       Margin="6,0,0,0"/>
+            <ui:Button x:Name="LogoutBtn"
+                       Content="Logout"
+                       Click="Logout_Click"
+                       Width="80" Height="30" Padding="4,2"
+                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                       Margin="6,0,0,0"
+                       Visibility="Collapsed"/>
+        </StackPanel>
+
+        <TextBlock FontSize="11" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,4,0,8"
+                   Text="Login opens a browser tab. Complete the sign-in there, then return here. The status will update automatically."/>
+
+        <Separator Margin="0,4,0,8"/>
+
+        <!-- Step 3: Tunnel -->
+        <TextBlock Text="Step 3: Tunnel" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,4"/>
+
+        <StackPanel Orientation="Horizontal" Margin="0,2,0,2">
+            <TextBlock Text="Tunnel:" Width="120" VerticalAlignment="Center"/>
+            <TextBlock x:Name="TunnelStatusText" Text="Stopped" VerticalAlignment="Center" FontSize="12" Margin="4,0,12,0"/>
+            <ui:Button x:Name="StartTunnelBtn"
+                       Content="Start"
+                       Click="StartTunnel_Click"
+                       Width="70" Height="30" Padding="4,2"
+                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+            <ui:Button x:Name="StopTunnelBtn"
+                       Content="Stop"
+                       Click="StopTunnel_Click"
+                       Width="70" Height="30" Padding="4,2"
+                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                       Margin="6,0,0,0"
+                       Visibility="Collapsed"/>
+        </StackPanel>
+
+        <StackPanel x:Name="TunnelUrlPanel" Orientation="Horizontal" Margin="0,6,0,2" Visibility="Collapsed">
+            <TextBlock Text="Webhook base URL:" Width="120" VerticalAlignment="Center"/>
+            <ui:TextBox x:Name="TunnelUrlBox" Width="400" Height="30" IsReadOnly="True"
+                        views:SettingsProperties.ExcludeFromUnsaved="True"
+                        FontSize="11" VerticalAlignment="Center"/>
+            <ui:Button Content="Copy"
+                       Click="CopyTunnelUrl_Click"
+                       Width="60" Height="30" Padding="4,2"
+                       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                       Margin="6,0,0,0"/>
+        </StackPanel>
+
+        <TextBlock FontSize="11" Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0,4,0,0"
+                   Text="The tunnel starts automatically on launch when you are already logged in. Use the base URL above to build your webhook URL (e.g. append /api/webhooks/kofi for Ko-fi)."/>
+
+    </StackPanel>
+
+</views:SettingsControl>

--- a/SubathonManager.UI/Views/SettingsViews/External/DevTunnelsSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/DevTunnelsSettings.xaml.cs
@@ -1,0 +1,226 @@
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using DevTunnels.Client.Authentication;
+using SubathonManager.Core;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Models;
+using SubathonManager.Core.Objects;
+using SubathonManager.Data;
+using SubathonManager.UI.Services;
+using TextBox = System.Windows.Controls.TextBox;
+
+namespace SubathonManager.UI.Views.SettingsViews.External;
+
+public partial class DevTunnelsSettings : SettingsControl
+{
+    public DevTunnelsSettings()
+    {
+        InitializeComponent();
+        Loaded += (_, _) =>
+        {
+            IntegrationEvents.ConnectionUpdated += UpdateStatus;
+            // Re-read the last-known state from the shared connection dict on every
+            // visit (including revisits after switching tabs), so we never show stale
+            // status even if DevTunnels events fired while this control was detached.
+            UpdateStatus(Utils.GetConnection(SubathonEventSource.DevTunnels, "Cli"));
+            UpdateStatus(Utils.GetConnection(SubathonEventSource.DevTunnels, "Login"));
+            UpdateStatus(Utils.GetConnection(SubathonEventSource.DevTunnels, "Tunnel"));
+        };
+
+        Unloaded += (_, _) =>
+        {
+            IntegrationEvents.ConnectionUpdated -= UpdateStatus;
+        };
+    }
+
+    // ISettingsControl
+
+    internal override void UpdateStatus(IntegrationConnection? connection)
+    {
+        if (connection is not { Source: SubathonEventSource.DevTunnels }) return;
+
+        Dispatcher.Invoke(() =>
+        {
+            switch (connection.Service)
+            {
+                case "Cli":
+                    ApplyCliState(connection.Status, connection.Name);
+                    break;
+                case "Login":
+                    ApplyLoginState(connection.Status, connection.Name);
+                    break;
+                case "Tunnel":
+                    ApplyTunnelState(connection.Status, connection.Name);
+                    break;
+            }
+        });
+    }
+
+    protected internal override void LoadValues(AppDbContext db) { }
+    public override bool UpdateValueSettings(AppDbContext db) => false;
+    public override void UpdateCurrencyBoxes(List<string> currencies, string selected) { }
+    public override (string, string, TextBox?, TextBox?) GetValueBoxes(SubathonValue val) => ("", "", null, null);
+
+    // State helpers
+
+    private void ApplyCliState(bool installed, string? version)
+    {
+        CliStatusText.Text = installed
+            ? (string.IsNullOrWhiteSpace(version) ? "Installed" : $"Installed (v{version})")
+            : "Not installed";
+
+        LoginButtonsPanel.IsEnabled = installed;
+
+        // Recompute Start button enabled state from stored connection dict to avoid
+        // cross-referencing service properties that may lag behind event state.
+        bool loggedIn = Utils.GetConnection(SubathonEventSource.DevTunnels, "Login").Status;
+        bool tunnelRunning = Utils.GetConnection(SubathonEventSource.DevTunnels, "Tunnel").Status;
+        StartTunnelBtn.IsEnabled = installed && loggedIn && !tunnelRunning;
+    }
+
+    private void ApplyLoginState(bool loggedIn, string? username)
+    {
+        LoginStatusText.Text = loggedIn
+            ? (string.IsNullOrWhiteSpace(username) ? "Logged in" : $"Logged in as {username}")
+            : "Not logged in";
+
+        LoginMicrosoftBtn.Visibility = loggedIn ? Visibility.Collapsed : Visibility.Visible;
+        LoginGithubBtn.Visibility = loggedIn ? Visibility.Collapsed : Visibility.Visible;
+        LogoutBtn.Visibility = loggedIn ? Visibility.Visible : Visibility.Collapsed;
+
+        bool cliInstalled = Utils.GetConnection(SubathonEventSource.DevTunnels, "Cli").Status;
+        bool tunnelRunning = Utils.GetConnection(SubathonEventSource.DevTunnels, "Tunnel").Status;
+        StartTunnelBtn.IsEnabled = loggedIn && cliInstalled && !tunnelRunning;
+    }
+
+    private void ApplyTunnelState(bool running, string? url)
+    {
+        if (url == "(starting…)")
+        {
+            TunnelStatusText.Text = "Starting…";
+            StartTunnelBtn.IsEnabled = false;
+            StopTunnelBtn.Visibility = Visibility.Collapsed;
+            StartTunnelBtn.Visibility = Visibility.Visible;
+            TunnelUrlPanel.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        TunnelStatusText.Text = running ? "Running" : "Stopped";
+
+        StartTunnelBtn.Visibility = running ? Visibility.Collapsed : Visibility.Visible;
+        StopTunnelBtn.Visibility = running ? Visibility.Visible : Visibility.Collapsed;
+
+        bool cliInstalled = Utils.GetConnection(SubathonEventSource.DevTunnels, "Cli").Status;
+        bool loggedIn = Utils.GetConnection(SubathonEventSource.DevTunnels, "Login").Status;
+        StartTunnelBtn.IsEnabled = !running && cliInstalled && loggedIn;
+
+        TunnelUrlPanel.Visibility = running && !string.IsNullOrWhiteSpace(url) ? Visibility.Visible : Visibility.Collapsed;
+        if (!string.IsNullOrWhiteSpace(url))
+            TunnelUrlBox.Text = url;
+    }
+
+    // Button handlers
+
+    private async void CheckCli_Click(object sender, RoutedEventArgs e)
+    {
+        CheckCliBtn.IsEnabled = false;
+        try
+        {
+            CliStatusText.Text = "Checking…";
+            await ServiceManager.DevTunnels.RefreshCliStatusAsync();
+        }
+        finally
+        {
+            CheckCliBtn.IsEnabled = true;
+        }
+    }
+
+    private void GetCli_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows#install",
+                UseShellExecute = true
+            });
+        }
+        catch { /**/ }
+    }
+
+    private async void LoginMicrosoft_Click(object sender, RoutedEventArgs e)
+        => await RunLoginAsync(LoginProvider.Microsoft);
+
+    private async void LoginGitHub_Click(object sender, RoutedEventArgs e)
+        => await RunLoginAsync(LoginProvider.GitHub);
+
+    private async Task RunLoginAsync(LoginProvider provider)
+    {
+        LoginMicrosoftBtn.IsEnabled = false;
+        LoginGithubBtn.IsEnabled = false;
+        LoginStatusText.Text = "Opening browser…";
+        try
+        {
+            await ServiceManager.DevTunnels.LoginAsync(provider);
+        }
+        finally
+        {
+            LoginMicrosoftBtn.IsEnabled = true;
+            LoginGithubBtn.IsEnabled = true;
+        }
+    }
+
+    private async void Logout_Click(object sender, RoutedEventArgs e)
+    {
+        LogoutBtn.IsEnabled = false;
+        try
+        {
+            await ServiceManager.DevTunnels.LogoutAsync();
+        }
+        finally
+        {
+            LogoutBtn.IsEnabled = true;
+        }
+    }
+
+    private async void StartTunnel_Click(object sender, RoutedEventArgs e)
+    {
+        StartTunnelBtn.IsEnabled = false;
+        try
+        {
+            await ServiceManager.DevTunnels.StartTunnelAsync();
+        }
+        finally
+        {
+            // State restored via connection update broadcast
+        }
+    }
+
+    private async void StopTunnel_Click(object sender, RoutedEventArgs e)
+    {
+        StopTunnelBtn.IsEnabled = false;
+        try
+        {
+            await ServiceManager.DevTunnels.StopTunnelAsync();
+        }
+        finally
+        {
+            StopTunnelBtn.IsEnabled = true;
+        }
+    }
+
+    private async void CopyTunnelUrl_Click(object sender, RoutedEventArgs e)
+    {
+        var url = TunnelUrlBox.Text;
+        if (string.IsNullOrWhiteSpace(url)) return;
+        var result = await UiUtils.UiUtils.TrySetClipboardTextAsync(url);
+        if (!result) return;
+        var btn = (sender as Wpf.Ui.Controls.Button)!;
+        var original = btn.Content;
+        btn.Content = "Copied!";
+        await Task.Delay(1500);
+        btn.Content = original;
+    }
+}

--- a/SubathonManager.UI/Views/SettingsViews/External/DevTunnelsSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/DevTunnelsSettings.xaml.cs
@@ -125,6 +125,7 @@ public partial class DevTunnelsSettings : SettingsControl
         bool cliInstalled = Utils.GetConnection(SubathonEventSource.DevTunnels, "Cli").Status;
         bool loggedIn = Utils.GetConnection(SubathonEventSource.DevTunnels, "Login").Status;
         StartTunnelBtn.IsEnabled = !running && cliInstalled && loggedIn;
+        StopTunnelBtn.IsEnabled = running;
 
         TunnelUrlPanel.Visibility = running && !string.IsNullOrWhiteSpace(url) ? Visibility.Visible : Visibility.Collapsed;
         if (!string.IsNullOrWhiteSpace(url))

--- a/SubathonManager.UI/Views/SettingsViews/External/DevTunnelsSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/DevTunnelsSettings.xaml.cs
@@ -107,6 +107,16 @@ public partial class DevTunnelsSettings : SettingsControl
             return;
         }
 
+        if (url == "(stopping…)")
+        {
+            TunnelStatusText.Text = "Stopping…";
+            StopTunnelBtn.IsEnabled = false;
+            StopTunnelBtn.Visibility = Visibility.Visible;
+            StartTunnelBtn.Visibility = Visibility.Collapsed;
+            TunnelUrlPanel.Visibility = Visibility.Collapsed;
+            return;
+        }
+
         TunnelStatusText.Text = running ? "Running" : "Stopped";
 
         StartTunnelBtn.Visibility = running ? Visibility.Collapsed : Visibility.Visible;
@@ -200,15 +210,7 @@ public partial class DevTunnelsSettings : SettingsControl
 
     private async void StopTunnel_Click(object sender, RoutedEventArgs e)
     {
-        StopTunnelBtn.IsEnabled = false;
-        try
-        {
-            await ServiceManager.DevTunnels.StopTunnelAsync();
-        }
-        finally
-        {
-            StopTunnelBtn.IsEnabled = true;
-        }
+        await ServiceManager.DevTunnels.StopTunnelAsync();
     }
 
     private async void CopyTunnelUrl_Click(object sender, RoutedEventArgs e)

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiCombinedSettings.xaml
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiCombinedSettings.xaml
@@ -1,0 +1,169 @@
+<views:SettingsControl x:Class="SubathonManager.UI.Views.SettingsViews.External.KoFiCombinedSettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             xmlns:views="clr-namespace:SubathonManager.UI.Views"
+             xmlns:validation="clr-namespace:SubathonManager.UI.Validation"
+             mc:Ignorable="d">
+
+    <StackPanel>
+
+        <!-- Connection type toggle -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10"
+                    views:SettingsProperties.ExcludeFromUnsaved="True">
+            <RadioButton x:Name="SocketRadio" Content="Socket" IsChecked="True"
+                         GroupName="KoFiConn" Checked="ConnectionType_Checked"
+                         VerticalAlignment="Center"/>
+            <RadioButton x:Name="WebhookRadio" Content="Webhook"
+                         GroupName="KoFiConn" Checked="ConnectionType_Checked"
+                         VerticalAlignment="Center" Margin="16,0,0,0"/>
+        </StackPanel>
+
+        <!-- Socket sub-control slot -->
+        <StackPanel x:Name="SocketSlot"
+                    views:SettingsProperties.ExcludeFromUnsaved="True"/>
+
+        <!-- Webhook sub-control slot -->
+        <StackPanel x:Name="WebhookSlot" Visibility="Collapsed"
+                    views:SettingsProperties.ExcludeFromUnsaved="True"/>
+
+        <Separator Margin="0,8,0,8"/>
+
+        <!-- Shared: conversion settings -->
+        <StackPanel Margin="10,5,0,5">
+
+            <Grid Margin="0,2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="300"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Text="Donations:" Width="100" VerticalAlignment="Center"
+                               ToolTip="Donations and Monthly Tips"/>
+                    <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True"
+                                PlaceholderText="12" x:Name="DonoBox"/>
+                    <TextBlock Margin="8,0,0,0" Text="Seconds per 1$" Width="150" VerticalAlignment="Center"/>
+                    <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True"
+                                PlaceholderText="0" x:Name="DonoBox2"/>
+                    <TextBlock Margin="8,0,0,0" Text="Points per 1$, rounded down" Width="180" VerticalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                    <ui:TextBox Margin="10,0,4,0" Width="80" Text="10.00" PlaceholderText="1.00"
+                                HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12"
+                                ClearButtonEnabled="False" Height="34"
+                                views:SettingsProperties.ExcludeFromUnsaved="True"
+                                validation:InputValidationBehavior.IsDecimalOnly="True"
+                                x:Name="SimulateKFTipAmountBox"/>
+                    <ComboBox Width="100" IsEditable="True" IsTextSearchEnabled="True"
+                              x:Name="CurrencyBox" StaysOpenOnEdit="True" Height="34"
+                              views:SettingsProperties.ExcludeFromUnsaved="True" Margin="4,0,4,0"/>
+                    <ui:Button Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                               Content="Test" Click="TestKoFiTip_Click"
+                               Width="60" Padding="2" Height="34" Margin="4,0,0,0"/>
+                </StackPanel>
+            </Grid>
+
+            <Grid Margin="0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="300"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Text="Shop Orders:" Width="100" VerticalAlignment="Center"
+                               ToolTip="Direct shop orders from the Ko-fi store (webhook only)"/>
+                    <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True"
+                                PlaceholderText="12" x:Name="ShopOrderBox"/>
+                    <TextBlock Margin="8,0,0,0" Text="Seconds per 1$" Width="150" VerticalAlignment="Center"/>
+                    <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True"
+                                PlaceholderText="0" x:Name="ShopOrderBox2"/>
+                    <TextBlock Margin="8,0,0,0" Text="Points per 1$, rounded down" Width="180" VerticalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                    <ui:TextBox Margin="10,0,4,0" Width="80" Text="10.00" PlaceholderText="1.00"
+                                HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12"
+                                ClearButtonEnabled="False" Height="34"
+                                views:SettingsProperties.ExcludeFromUnsaved="True"
+                                validation:InputValidationBehavior.IsDecimalOnly="True"
+                                x:Name="SimulateKFOrderAmountBox"/>
+                    <ComboBox Width="100" IsEditable="True" IsTextSearchEnabled="True"
+                              x:Name="OrderCurrencyBox" StaysOpenOnEdit="True" Height="34"
+                              views:SettingsProperties.ExcludeFromUnsaved="True" Margin="4,0,4,0"/>
+                    <ui:Button Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                               Content="Test" Click="TestKoFiShopOrder_Click"
+                               Width="60" Padding="2" Height="34" Margin="4,0,0,0"/>
+                </StackPanel>
+            </Grid>
+
+            <Grid Margin="0,4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="300"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <TextBlock Text="Commissions:" Width="100" VerticalAlignment="Center"
+                               ToolTip="Commission services offered via Ko-fi (webhook only)"/>
+                    <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True"
+                                PlaceholderText="12" x:Name="CommissionBox"/>
+                    <TextBlock Margin="8,0,0,0" Text="Seconds per 1$" Width="150" VerticalAlignment="Center"/>
+                    <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True"
+                                PlaceholderText="0" x:Name="CommissionBox2"/>
+                    <TextBlock Margin="8,0,0,0" Text="Points per 1$, rounded down" Width="180" VerticalAlignment="Center"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                    <ui:TextBox Margin="10,0,4,0" Width="80" Text="10.00" PlaceholderText="1.00"
+                                HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="12"
+                                ClearButtonEnabled="False" Height="34"
+                                views:SettingsProperties.ExcludeFromUnsaved="True"
+                                validation:InputValidationBehavior.IsDecimalOnly="True"
+                                x:Name="SimulateKFCommissionAmountBox"/>
+                    <ComboBox Width="100" IsEditable="True" IsTextSearchEnabled="True"
+                              x:Name="CommissionCurrencyBox" StaysOpenOnEdit="True" Height="34"
+                              views:SettingsProperties.ExcludeFromUnsaved="True" Margin="4,0,4,0"/>
+                    <ui:Button Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                               Content="Test" Click="TestKoFiCommission_Click"
+                               Width="60" Padding="2" Height="34" Margin="4,0,0,0"/>
+                </StackPanel>
+            </Grid>
+
+        </StackPanel>
+
+        <!-- Memberships -->
+        <Expander Header="Memberships" IsExpanded="False" Margin="0,5,0,0">
+            <StackPanel x:Name="MembershipsPanel" Margin="10,5,0,5">
+                <Grid x:Name="DefaultMember" Margin="0,2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="400"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Horizontal" Margin="4,2">
+                        <TextBlock Text="Default:" Width="160" VerticalAlignment="Center" Margin="8,0,0,0"/>
+                        <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True"
+                                    PlaceholderText="60" x:Name="KFSubDTextBox" Height="36"/>
+                        <TextBlock Margin="8,0,0,0" Text="Seconds" Width="120" VerticalAlignment="Center"/>
+                        <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True"
+                                    Height="36" PlaceholderText="1" x:Name="KFSubDTextBox2"/>
+                        <TextBlock Margin="8,0,0,0" Text="Points" Width="100" VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <ui:Button Icon="Add24" Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                   Height="36" Content="Add Membership Tier" x:Name="AddBtn"
+                                   Click="AddMembership_Click" Width="160" Margin="4,5,4,5"/>
+                        <ComboBox Text="Tier" Width="150" Height="36" FontSize="12"
+                                  x:Name="SimKoFiTierSelection" ToolTip="Select Membership Tier"
+                                  views:SettingsProperties.ExcludeFromUnsaved="True"
+                                  SelectedIndex="0" Margin="4,0,4,0">
+                            <ComboBoxItem Content="DEFAULT"/>
+                        </ComboBox>
+                        <ui:Button Icon="Add24" Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                   Content="Test" Click="TestKoFiSub_Click"
+                                   Width="60" Padding="2" Height="36" Margin="4,0,0,0"/>
+                    </StackPanel>
+                </Grid>
+            </StackPanel>
+        </Expander>
+
+    </StackPanel>
+
+</views:SettingsControl>

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiCombinedSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiCombinedSettings.xaml.cs
@@ -1,0 +1,405 @@
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SubathonManager.Core;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Models;
+using SubathonManager.Core.Objects;
+using SubathonManager.Data;
+using SubathonManager.Integration;
+using SubathonManager.UI.Validation;
+using TextBox = System.Windows.Controls.TextBox;
+
+namespace SubathonManager.UI.Views.SettingsViews.External;
+
+public partial class KoFiCombinedSettings : SettingsControl
+{
+    private readonly IDbContextFactory<AppDbContext> _factory;
+    private List<KoFiSubRow> _dynamicSubRows = new();
+
+    private KoFiSettings? _socket;
+    private KoFiWebhookSettings? _webhook;
+
+    public KoFiCombinedSettings()
+    {
+        _factory = AppServices.Provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        InitializeComponent();
+
+        Loaded += (_, _) =>
+        {
+            RegisterUnsavedChangeHandlers();
+        };
+    }
+
+    public override void Init(SettingsView host)
+    {
+        base.Init(host);
+
+        _socket = new KoFiSettings();
+        _webhook = new KoFiWebhookSettings();
+
+        _socket.Init(host);
+        _webhook.Init(host);
+
+        SocketSlot.Children.Add(_socket);
+        WebhookSlot.Children.Add(_webhook);
+    }
+
+    internal override void UpdateStatus(IntegrationConnection? connection) { }
+
+    // Toggle
+
+    private void ConnectionType_Checked(object sender, RoutedEventArgs e)
+    {
+        if (!IsLoaded) return;
+        bool isWebhook = WebhookRadio.IsChecked == true;
+        SocketSlot.Visibility = isWebhook ? Visibility.Collapsed : Visibility.Visible;
+        WebhookSlot.Visibility = isWebhook ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    // Config + DB persistence
+
+    protected internal override void LoadValues(AppDbContext db)
+    {
+        SuppressUnsavedChanges(() => LoadValuesCore(db));
+    }
+
+    private void LoadValuesCore(AppDbContext db)
+    {
+        _webhook?.LoadValues(db);
+
+        var config = AppServices.Provider.GetRequiredService<IConfig>();
+        bool hasToken = !string.IsNullOrWhiteSpace(
+            config.GetFromEncoded("KoFi", "VerificationToken", string.Empty));
+        WebhookRadio.IsChecked = hasToken;
+        SocketRadio.IsChecked = !hasToken;
+        SocketSlot.Visibility = hasToken ? Visibility.Collapsed : Visibility.Visible;
+        WebhookSlot.Visibility = hasToken ? Visibility.Visible : Visibility.Collapsed;
+
+        var values = db.SubathonValues.Where(v => v.EventType == SubathonEventType.KoFiSub)
+            .OrderBy(meta => meta)
+            .AsNoTracking().ToList();
+
+        for (int i = MembershipsPanel.Children.Count - 1; i >= 0; i--)
+        {
+            var child = MembershipsPanel.Children[i];
+            if (child is FrameworkElement fe && fe.Name != "DefaultMember" && fe.Name != "AddBtn")
+                MembershipsPanel.Children.RemoveAt(i);
+        }
+        _dynamicSubRows.Clear();
+
+        foreach (var value in values)
+        {
+            if (value is { Meta: "DEFAULT", EventType: SubathonEventType.KoFiSub })
+                Host.UpdateTimePointsBoxes(KFSubDTextBox, KFSubDTextBox2, $"{value.Seconds}", $"{value.Points}");
+            else if (value.EventType == SubathonEventType.KoFiSub)
+                AddMembershipRow(value);
+        }
+
+        RefreshTierCombo();
+    }
+
+    protected internal override bool UpdateConfigValueSettings()
+        => _webhook?.UpdateConfigValueSettings() ?? false;
+
+    public override bool UpdateValueSettings(AppDbContext db)
+    {
+        bool hasUpdated = false;
+
+        var tipValue = db.SubathonValues.FirstOrDefault(sv => sv.EventType == SubathonEventType.KoFiDonation);
+        if (tipValue != null)
+        {
+            if (double.TryParse(DonoBox.Text, out var s) && !s.Equals(tipValue.Seconds)) { tipValue.Seconds = s; hasUpdated = true; }
+            if (double.TryParse(DonoBox2.Text, out var p) && !p.Equals(tipValue.Points)) { tipValue.Points = p; hasUpdated = true; }
+        }
+
+        var shopValue = db.SubathonValues.FirstOrDefault(sv => sv.EventType == SubathonEventType.KoFiShopOrder);
+        if (shopValue != null)
+        {
+            if (double.TryParse(ShopOrderBox.Text, out var s) && !s.Equals(shopValue.Seconds)) { shopValue.Seconds = s; hasUpdated = true; }
+            if (double.TryParse(ShopOrderBox2.Text, out var p) && !p.Equals(shopValue.Points)) { shopValue.Points = p; hasUpdated = true; }
+        }
+
+        var commValue = db.SubathonValues.FirstOrDefault(sv => sv.EventType == SubathonEventType.KoFiCommissionOrder);
+        if (commValue != null)
+        {
+            if (double.TryParse(CommissionBox.Text, out var s) && !s.Equals(commValue.Seconds)) { commValue.Seconds = s; hasUpdated = true; }
+            if (double.TryParse(CommissionBox2.Text, out var p) && !p.Equals(commValue.Points)) { commValue.Points = p; hasUpdated = true; }
+        }
+
+        var defaultSub = db.SubathonValues.FirstOrDefault(sv =>
+            sv.EventType == SubathonEventType.KoFiSub && sv.Meta == "DEFAULT");
+        if (defaultSub != null)
+        {
+            if (double.TryParse(KFSubDTextBox.Text, out var s) && !s.Equals(defaultSub.Seconds)) { defaultSub.Seconds = s; hasUpdated = true; }
+            if (double.TryParse(KFSubDTextBox2.Text, out var p) && !p.Equals(defaultSub.Points)) { defaultSub.Points = p; hasUpdated = true; }
+        }
+
+        var removeRows = _dynamicSubRows.Where(r => string.IsNullOrWhiteSpace(r.NameBox.Text)).ToList();
+        if (removeRows.Count > 0) hasUpdated = true;
+        foreach (var row in removeRows)
+            DeleteRow(row.SubValue, row);
+
+        EnsureUniqueName(_dynamicSubRows);
+
+        foreach (var subRow in _dynamicSubRows)
+        {
+            string meta = subRow.NameBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(meta)) { DeleteRow(subRow.SubValue, subRow); hasUpdated = true; continue; }
+            if (meta == "DEFAULT") continue;
+
+            if (!double.TryParse(subRow.TimeBox.Text, out double seconds)) seconds = 0;
+            if (!double.TryParse(subRow.PointsBox.Text, out double points)) points = 0;
+
+#pragma warning disable CA1862
+            var existing = db.SubathonValues.FirstOrDefault(sv =>
+                sv.EventType == SubathonEventType.KoFiSub && sv.Meta.ToLower() == meta.ToLower());
+#pragma warning restore CA1862
+            if (existing != null)
+            {
+                existing.Seconds = seconds;
+                existing.Points = points;
+                subRow.SubValue = existing;
+                if (!seconds.Equals(existing.Seconds) || !points.Equals(existing.Points))
+                    hasUpdated = true;
+            }
+            else
+            {
+                subRow.SubValue.Meta = meta;
+                subRow.SubValue.Seconds = seconds;
+                subRow.SubValue.Points = points;
+                db.SubathonValues.Add(subRow.SubValue);
+                hasUpdated = true;
+            }
+        }
+
+        List<string> names = ["DEFAULT"];
+        foreach (var row in _dynamicSubRows)
+            names.Add(row.NameBox.Text.Trim());
+
+        var stale = db.SubathonValues.Where(x =>
+            !names.Contains(x.Meta) && x.EventType == SubathonEventType.KoFiSub).ToList();
+        if (stale.Count > 0) { db.SubathonValues.RemoveRange(stale); hasUpdated = true; }
+
+        return hasUpdated;
+    }
+
+    public override (string, string, TextBox?, TextBox?) GetValueBoxes(SubathonValue val)
+    {
+        string v = $"{val.Seconds}";
+        string p = $"{val.Points}";
+        return val.EventType switch
+        {
+            SubathonEventType.KoFiDonation => (v, p, DonoBox, DonoBox2),
+            SubathonEventType.KoFiShopOrder => (v, p, ShopOrderBox, ShopOrderBox2),
+            SubathonEventType.KoFiCommissionOrder => (v, p, CommissionBox, CommissionBox2),
+            _ => (v, p, null, null)
+        };
+    }
+
+    public override void UpdateCurrencyBoxes(List<string> currencies, string selected)
+    {
+        CurrencyBox.ItemsSource = currencies;
+        CurrencyBox.SelectedItem = selected;
+        OrderCurrencyBox.ItemsSource = currencies;
+        OrderCurrencyBox.SelectedItem = selected;
+        CommissionCurrencyBox.ItemsSource = currencies;
+        CommissionCurrencyBox.SelectedItem = selected;
+    }
+
+    // Membership tiers
+
+    public void RefreshTierCombo()
+    {
+        string selectedTier = SimKoFiTierSelection.SelectedItem is ComboBoxItem item
+            ? item.Content?.ToString() ?? ""
+            : "";
+        using var db = _factory.CreateDbContext();
+
+        var metas = db.SubathonValues
+            .Where(v => v.EventType == SubathonEventType.KoFiSub)
+            .Select(v => v.Meta)
+            .Where(meta => meta != "DEFAULT" && !string.IsNullOrWhiteSpace(meta))
+            .Distinct()
+            .OrderBy(meta => meta)
+            .AsNoTracking()
+            .ToList();
+
+        SimKoFiTierSelection.Items.Clear();
+        SimKoFiTierSelection.Items.Add(new ComboBoxItem { Content = "DEFAULT" });
+        foreach (var meta in metas)
+            SimKoFiTierSelection.Items.Add(new ComboBoxItem { Content = meta });
+
+        foreach (var comboItem in SimKoFiTierSelection.Items)
+        {
+            if (comboItem is not ComboBoxItem cbi ||
+                !string.Equals(cbi.Content?.ToString(), selectedTier, StringComparison.OrdinalIgnoreCase)) continue;
+            SimKoFiTierSelection.SelectedItem = cbi;
+            break;
+        }
+
+        SimKoFiTierSelection.SelectedItem ??= SimKoFiTierSelection.Items[0];
+    }
+
+    private KoFiSubRow AddMembershipRow(SubathonValue subathonValue)
+    {
+        var row = new Grid { Margin = new Thickness(0, 2, 0, 2) };
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(300) });
+
+        var panelRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 2, 0, 2) };
+        var nameBox = new Wpf.Ui.Controls.TextBox
+        {
+            Width = 154, Text = subathonValue.Meta ?? "",
+            ToolTip = "Tier Name", PlaceholderText = "Tier Name",
+            Margin = new Thickness(0, 0, 6, 0), VerticalAlignment = VerticalAlignment.Center
+        };
+        var secondsBox = new Wpf.Ui.Controls.TextBox
+        {
+            Width = 100, Text = $"{subathonValue.Seconds}", PlaceholderText = "Seconds",
+            VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(12, 0, 0, 0)
+        };
+        var pointsBox = new Wpf.Ui.Controls.TextBox
+        {
+            Width = 100, Text = $"{subathonValue.Points}", PlaceholderText = "Points",
+            VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(128, 0, 0, 0)
+        };
+        var deleteBtn = new Wpf.Ui.Controls.Button
+        {
+            ToolTip = "Delete",
+            Icon = new Wpf.Ui.Controls.SymbolIcon
+            {
+                Symbol = Wpf.Ui.Controls.SymbolRegular.Delete24,
+                Margin = new Thickness(2), HorizontalAlignment = HorizontalAlignment.Center
+            },
+            Foreground = System.Windows.Media.Brushes.Red,
+            Cursor = System.Windows.Input.Cursors.Hand,
+            Width = 36, Height = 36, Margin = new Thickness(64, 0, 0, 0)
+        };
+
+        InputValidationBehavior.SetIsDecimalOnly(secondsBox, true);
+        InputValidationBehavior.SetIsDecimalOnly(pointsBox, true);
+
+        WireControl(nameBox);
+        WireControl(secondsBox);
+        WireControl(pointsBox);
+
+        panelRow.Children.Add(nameBox);
+        panelRow.Children.Add(secondsBox);
+        panelRow.Children.Add(pointsBox);
+        panelRow.Children.Add(deleteBtn);
+        row.Children.Add(panelRow);
+        MembershipsPanel.Children.Add(row);
+
+        var subRow = new KoFiSubRow
+        {
+            SubValue = subathonValue,
+            NameBox = nameBox,
+            TimeBox = secondsBox,
+            PointsBox = pointsBox,
+            RowGrid = row
+        };
+        _dynamicSubRows.Add(subRow);
+
+        deleteBtn.Click += (_, _) => DeleteRow(subathonValue, subRow);
+        return subRow;
+    }
+
+    private void DeleteRow(SubathonValue subathonValue, KoFiSubRow subRow)
+    {
+        using var db = _factory.CreateDbContext();
+        var dbRow = db.SubathonValues.FirstOrDefault(x =>
+            x.Meta == subathonValue.Meta && x.EventType == subathonValue.EventType);
+        if (dbRow != null) { db.SubathonValues.Remove(dbRow); db.SaveChanges(); }
+        _dynamicSubRows.Remove(subRow);
+        MembershipsPanel.Children.Remove(subRow.RowGrid);
+    }
+
+    private void AddMembership_Click(object sender, RoutedEventArgs e)
+    {
+        var name = $"New {_dynamicSubRows.Count}";
+        var allNames = _dynamicSubRows.Select(x => x.NameBox.Text.Trim()).ToArray();
+        while (allNames.Contains(name)) name = $"New {name}";
+        allNames = _dynamicSubRows.Select(x => x.SubValue.Meta.Trim()).ToArray();
+        while (allNames.Contains(name)) name = $"New {name}";
+        AddMembershipRow(new SubathonValue { EventType = SubathonEventType.KoFiSub, Meta = name, Seconds = 0, Points = 0 });
+    }
+
+    private static void EnsureUniqueName(List<KoFiSubRow> rows)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in rows)
+        {
+            string current = row.NameBox.Text.Trim();
+            while (!seen.Add(current.ToLower()))
+                current = "New " + current;
+            row.NameBox.Text = current;
+        }
+    }
+
+    // Test buttons
+
+    private void TestKoFiTip_Click(object sender, RoutedEventArgs e)
+    {
+        var data = new Dictionary<string, JsonElement>
+        {
+            { "user", JsonSerializer.SerializeToElement("SYSTEM") },
+            { "type", JsonSerializer.SerializeToElement(nameof(SubathonEventType.KoFiDonation)) },
+            { "currency", JsonSerializer.SerializeToElement(CurrencyBox.Text) },
+            { "amount", JsonSerializer.SerializeToElement(SimulateKFTipAmountBox.Text) }
+        };
+        ExternalEventService.ProcessExternalDonation(data);
+    }
+
+    private void TestKoFiShopOrder_Click(object sender, RoutedEventArgs e)
+    {
+        var data = new Dictionary<string, JsonElement>
+        {
+            { "user", JsonSerializer.SerializeToElement("SYSTEM") },
+            { "type", JsonSerializer.SerializeToElement(nameof(SubathonEventType.KoFiShopOrder)) },
+            { "currency", JsonSerializer.SerializeToElement(OrderCurrencyBox.Text) },
+            { "amount", JsonSerializer.SerializeToElement(SimulateKFOrderAmountBox.Text) }
+        };
+        ExternalEventService.ProcessExternalDonation(data);
+    }
+
+    private void TestKoFiCommission_Click(object sender, RoutedEventArgs e)
+    {
+        var data = new Dictionary<string, JsonElement>
+        {
+            { "user", JsonSerializer.SerializeToElement("SYSTEM") },
+            { "type", JsonSerializer.SerializeToElement(nameof(SubathonEventType.KoFiCommissionOrder)) },
+            { "currency", JsonSerializer.SerializeToElement(CommissionCurrencyBox.Text) },
+            { "amount", JsonSerializer.SerializeToElement(SimulateKFCommissionAmountBox.Text) }
+        };
+        ExternalEventService.ProcessExternalDonation(data);
+    }
+
+    private void TestKoFiSub_Click(object sender, RoutedEventArgs e)
+    {
+        string selectedTier = SimKoFiTierSelection.SelectedItem is ComboBoxItem item
+            ? item.Content?.ToString() ?? ""
+            : "";
+        var data = new Dictionary<string, JsonElement>
+        {
+            { "user", JsonSerializer.SerializeToElement("SYSTEM") },
+            { "type", JsonSerializer.SerializeToElement(nameof(SubathonEventType.KoFiSub)) },
+            { "value", JsonSerializer.SerializeToElement(selectedTier) },
+            { "currency", JsonSerializer.SerializeToElement("member") }
+        };
+        ExternalEventService.ProcessExternalSub(data);
+    }
+}
+
+public class KoFiSubRow
+{
+    public required SubathonValue SubValue { get; set; }
+    public required Wpf.Ui.Controls.TextBox NameBox { get; set; }
+    public required Wpf.Ui.Controls.TextBox TimeBox { get; set; }
+    public required Wpf.Ui.Controls.TextBox PointsBox { get; set; }
+    public required Grid RowGrid { get; set; }
+}

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiSettings.xaml
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiSettings.xaml
@@ -1,114 +1,19 @@
-﻿<views:SettingsControl x:Class="SubathonManager.UI.Views.SettingsViews.External.KoFiSettings"
+<views:SettingsControl x:Class="SubathonManager.UI.Views.SettingsViews.External.KoFiSettings"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:local="clr-namespace:SubathonManager.UI.Views.SettingsViews"
-             xmlns:validation="clr-namespace:SubathonManager.UI.Validation"
              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-             xmlns:views="clr-namespace:SubathonManager.UI.Views">
-<!-- <Expander Header="KoFi" IsExpanded="False"> -->
-    <StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0 0 0 6">
-            <ui:Button Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                       Content="Setup"
-                       Click="OpenKoFiSetup_Click"
-                       Width="60" Padding="2"
-                       Height="34"
-                       Margin="0,0,6,0"></ui:Button>
-            <ui:Button Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                       Content="Copy StreamerBot Import String"
-                       Click="CopyImportString_Click"
-                       Width="240" Padding="2"
-                       Height="34"
-                       Cursor = "Hand"
-                       Margin="6,0,0,0"></ui:Button>
-            
-            <TextBlock x:Name="KoFiStatusText" Text="Disconnected" VerticalAlignment="Center" FontSize="12" Margin="14 0 0 0"/>
-        </StackPanel>
-        <StackPanel Margin="10,5,0,5">
-            <Grid Margin="0,2">
-                
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="300"/>
-                </Grid.ColumnDefinitions>
-                
-                <StackPanel Grid.Column="0" Orientation="Horizontal">
-                    <TextBlock Text="Donations:" Width="100" VerticalAlignment="Center" ToolTip="Donations and Monthly Tips"/>
-                    <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True" PlaceholderText="12"
-                                x:Name="DonoBox"/>
-                    <TextBlock Margin="8 0 0 0" Text="Seconds per 1$" Width="150" VerticalAlignment="Center"/>
-                    
-                    <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True" PlaceholderText="0"
-                                x:Name="DonoBox2"/>
-                    <TextBlock Margin="8 0 0 0"  Text="Points per 1$, rounded down" Width="180" VerticalAlignment="Center"/>
-                </StackPanel>
-                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
-                    <ui:TextBox Margin="10 0 4 0" Width="80" Text="10.00"
-                                PlaceholderText="1.00"
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                FontSize="12"
-                                ClearButtonEnabled="False"
-                                Height="34" views:SettingsProperties.ExcludeFromUnsaved="True"
-                                validation:InputValidationBehavior.IsDecimalOnly="True" x:Name="SimulateKFTipAmountBox"/>
-                    
-                    <ComboBox Width="100" IsEditable="True" IsTextSearchEnabled="True" 
-                              x:Name="CurrencyBox" StaysOpenOnEdit="True"  Height="34" views:SettingsProperties.ExcludeFromUnsaved="True"
-                              Margin="4 0 4 0">
-                    </ComboBox>
-                    <ui:Button Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                               Content="Test"
-                               Click="TestKoFiTip_Click"
-                               Width="60" Padding="2"
-                               Height="34"
-                               Margin="4,0,0,0"></ui:Button>
-                </StackPanel>
-            </Grid>
-        </StackPanel>
-        
-        <Expander Header="Memberships" IsExpanded="False" Margin="0,5,0,0">
-                <StackPanel x:Name="MembershipsPanel" Margin="10,5,0,5">
-                    <Grid x:Name="DefaultMember" Margin="0,2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="400"/>
-                        </Grid.ColumnDefinitions>
-                        <StackPanel Orientation="Horizontal" Margin="4,2">
-                            <TextBlock Text="Default:" Width="160" VerticalAlignment="Center" Margin="8 0 0 0 "/>
-                            <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True" PlaceholderText="60"
-                                        x:Name="KFSubDTextBox" Height="36"/>
-                            <TextBlock Margin="8 0 0 0" Text="Seconds" Width="120" VerticalAlignment="Center"/>
-                            <ui:TextBox Width="100" validation:InputValidationBehavior.IsDecimalOnly="True" Height="36" PlaceholderText="1"
-                                        x:Name="KFSubDTextBox2"/>
-                            <TextBlock Margin="8 0 0 0"  Text="Points" Width="100" VerticalAlignment="Center"/>
-                        </StackPanel>
-                        
-                        <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
-                            <ui:Button Icon="Add24" Foreground="{DynamicResource TextFillColorPrimaryBrush}" Height="36"
-                                       Content="Add Membership Tier" x:Name="AddBtn"
-                                       Click="AddMembership_Click"
-                                       Width="160" Margin="4,5,4,5"/>
-                            <ComboBox Text="Tier" Width="150" Height="36" FontSize="12" 
-                                      x:Name="SimKoFiTierSelection" ToolTip="Select Membership Tier"
-                                      views:SettingsProperties.ExcludeFromUnsaved="True"
-                                      SelectedIndex="0" Margin="4 0 4 0">
-                                <ComboBoxItem Content="DEFAULT"/> <!-- Will populate from subathon values -->
-                            </ComboBox>
-                            <ui:Button Icon="Add24" Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                Content="Test"
-                                Click="TestKoFiSub_Click"
-                                Width="60" Padding="2"
-                                Height="36"
-                                Margin="4,0,0,0">
-                            </ui:Button>
-                        </StackPanel>
-                        
-                    </Grid>
-                </StackPanel>
-            
-            </Expander>
+             xmlns:views="clr-namespace:SubathonManager.UI.Views"
+             mc:Ignorable="d">
+    <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+        <ui:Button Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                   Content="Setup" Click="OpenKoFiSetup_Click"
+                   Width="60" Padding="2" Height="34" Margin="0,0,6,0"/>
+        <ui:Button Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                   Content="Copy StreamerBot Import String" Click="CopyImportString_Click"
+                   Width="240" Padding="2" Height="34" Cursor="Hand" Margin="6,0,0,0"/>
+        <TextBlock x:Name="KoFiStatusText" Text="Disconnected"
+                   VerticalAlignment="Center" FontSize="12" Margin="14,0,0,0"/>
     </StackPanel>
-<!-- </Expander> -->
 </views:SettingsControl>

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiSettings.xaml.cs
@@ -1,9 +1,7 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Net.Http;
-using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SubathonManager.Core;
@@ -12,28 +10,21 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
 using SubathonManager.Data;
-using SubathonManager.Integration;
-using SubathonManager.UI.Validation;
 
 namespace SubathonManager.UI.Views.SettingsViews.External;
 
 public partial class KoFiSettings : SettingsControl
 {
-    private readonly IDbContextFactory<AppDbContext> _factory;
     private readonly ILogger? _logger = AppServices.Provider.GetRequiredService<ILogger<KoFiSettings>>();
-    private List<KoFiSubRow> _dynamicSubRows = new();
 
     public KoFiSettings()
     {
-        _factory = AppServices.Provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
         InitializeComponent();
         Loaded += (_, _) =>
         {
             IntegrationEvents.ConnectionUpdated += UpdateStatus;
-            RegisterUnsavedChangeHandlers();
             UpdateStatus(Utils.GetConnection(SubathonEventSource.KoFi, "Socket"));
         };
-
         Unloaded += (_, _) =>
         {
             IntegrationEvents.ConnectionUpdated -= UpdateStatus;
@@ -45,348 +36,8 @@ public partial class KoFiSettings : SettingsControl
         if (connection is not { Source: SubathonEventSource.KoFi } || connection.Service != "Socket") return;
         Host.UpdateConnectionStatus(connection.Status, KoFiStatusText, null);
     }
-    protected internal override void LoadValues(AppDbContext db)
-    {
-        SuppressUnsavedChanges(() => LoadValuesCore(db));
-    }
-    
-    private void LoadValuesCore(AppDbContext db)
-    {
-        var values = db.SubathonValues.Where(v => v.EventType == SubathonEventType.KoFiSub)
-            .OrderBy(meta => meta)
-            .AsNoTracking().ToList();
 
-        for (int i = MembershipsPanel.Children.Count - 1; i >= 0; i--)
-        {
-            var child = MembershipsPanel.Children[i];
-
-            if (child is FrameworkElement fe && fe.Name != "DefaultMember" && fe.Name != "AddBtn")
-            {
-                MembershipsPanel.Children.RemoveAt(i);
-            }
-        }
-        _dynamicSubRows.Clear();
-        foreach (var value in values)
-        {      
-            TextBox? box1 = null;
-            TextBox? box2 = null;
-            var v = $"{value.Seconds}";
-            var p = $"{value.Points}";
-            
-            if (value is { Meta: "DEFAULT", EventType: SubathonEventType.KoFiSub })
-            {
-                box1 = KFSubDTextBox;
-                box2 = KFSubDTextBox2;
-            }
-            else if (value.EventType == SubathonEventType.KoFiSub)
-            {
-                KoFiSubRow row = AddMembershipRow(value);
-            }
-
-            if (!string.IsNullOrWhiteSpace(v) && !string.IsNullOrWhiteSpace(p) && box1 != null && box2 != null)
-            {
-                Host.UpdateTimePointsBoxes(box1, box2, v, p);
-            }
-        }
-
-        RefreshTierCombo();
-    }
-
-    private void TestKoFiSub_Click(object sender, RoutedEventArgs e)
-    {
-        string selectedTier = (SimKoFiTierSelection.SelectedItem is ComboBoxItem item) 
-            ? item.Content?.ToString() ?? "" 
-            : "";       
-        Dictionary<string, JsonElement> data = new Dictionary<string, JsonElement>();
-        data.Add("user", JsonSerializer.SerializeToElement("SYSTEM"));
-        data.Add("type", JsonSerializer.SerializeToElement(nameof(SubathonEventType.KoFiSub)));
-        data.Add("value", JsonSerializer.SerializeToElement(selectedTier));
-        data.Add("currency", JsonSerializer.SerializeToElement("member"));
-        ExternalEventService.ProcessExternalSub(data);
-    }
-    
-    public void RefreshTierCombo()
-    {
-        string selectedTier = (SimKoFiTierSelection.SelectedItem is ComboBoxItem item) 
-            ? item.Content?.ToString() ?? "" 
-            : "";       
-        using var db = _factory.CreateDbContext();
-
-        var metas = db.SubathonValues
-            .Where(v => v.EventType == SubathonEventType.KoFiSub)
-            .Select(v => v.Meta)
-            .Where(meta => meta != "DEFAULT" && !string.IsNullOrWhiteSpace(meta))
-            .Distinct()
-            .OrderBy(meta => meta)
-            .AsNoTracking()
-            .ToList();
-
-        SimKoFiTierSelection.Items.Clear();
-        SimKoFiTierSelection.Items.Add(new ComboBoxItem{Content = "DEFAULT"});
-        foreach (var meta in metas)
-            SimKoFiTierSelection.Items.Add(new ComboBoxItem { Content = meta });
-
-        foreach (var comboItem in SimKoFiTierSelection.Items)
-        {
-            if (comboItem is not ComboBoxItem cbi || !string.Equals(cbi.Content?.ToString(), selectedTier,
-                    StringComparison.OrdinalIgnoreCase)) continue;
-            SimKoFiTierSelection.SelectedItem = cbi;
-            break;
-        }
-
-        SimKoFiTierSelection.SelectedItem ??= SimKoFiTierSelection.Items[0];
-    }
-    
-    private void TestKoFiTip_Click(object sender, RoutedEventArgs e)
-    {
-        var value = SimulateKFTipAmountBox.Text;
-        var currency = CurrencyBox.Text;
-        Dictionary<string, JsonElement> data = new Dictionary<string, JsonElement>();
-        data.Add("user", JsonSerializer.SerializeToElement("SYSTEM"));
-        data.Add("type", JsonSerializer.SerializeToElement(nameof(SubathonEventType.KoFiDonation)));
-        data.Add("currency", JsonSerializer.SerializeToElement(currency));
-        data.Add("amount", JsonSerializer.SerializeToElement(value));
-        ExternalEventService.ProcessExternalDonation(data);
-    }
-
-    private KoFiSubRow AddMembershipRow(SubathonValue subathonValue)
-    {
-        var row = new Grid
-        {
-            Margin = new Thickness(0, 2, 0 ,2),
-        };
-        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
-        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(300) });
-        
-        var panelRow = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 2, 0, 2) };
-        var nameBox = new Wpf.Ui.Controls.TextBox { Width = 154, Text = subathonValue.Meta ?? "", 
-            ToolTip = "Tier Name", PlaceholderText = "Tier Name",
-            Margin = new Thickness(0, 0, 6, 0), VerticalAlignment = VerticalAlignment.Center };
-        var secondsBox = new Wpf.Ui.Controls.TextBox { Width = 100, Text = $"{subathonValue.Seconds}", PlaceholderText = "Seconds",
-            VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(12, 0, 0, 0)};
-        var pointsBox = new Wpf.Ui.Controls.TextBox { Width = 100, Text = $"{subathonValue.Points}", PlaceholderText = "Points",
-            VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(128, 0, 0, 0) };
-        var deleteBtn = new Wpf.Ui.Controls.Button { ToolTip="Delete", 
-            Icon = new Wpf.Ui.Controls.SymbolIcon { Symbol = Wpf.Ui.Controls.SymbolRegular.Delete24,
-                Margin = new Thickness(2), HorizontalAlignment = HorizontalAlignment.Center},
-            Foreground = System.Windows.Media.Brushes.Red,
-            Cursor = System.Windows.Input.Cursors.Hand,
-            Width = 36, Height = 36, Margin = new Thickness(64,0,0,0) };
-        
-        InputValidationBehavior.SetIsDecimalOnly(secondsBox, true);
-        InputValidationBehavior.SetIsDecimalOnly(pointsBox, true);
-        
-        WireControl(nameBox);
-        WireControl(secondsBox);
-        WireControl(pointsBox);
-        
-        panelRow.Children.Add(nameBox);
-        panelRow.Children.Add(secondsBox);
-        panelRow.Children.Add(pointsBox);
-        panelRow.Children.Add(deleteBtn);
-        
-        row.Children.Add(panelRow);
-
-        MembershipsPanel.Children.Add(row);
-
-        var subRow = new KoFiSubRow
-        {
-            SubValue = subathonValue,
-            NameBox = nameBox,
-            TimeBox = secondsBox,
-            PointsBox = pointsBox,
-            RowGrid = row
-        };
-        
-        _dynamicSubRows.Add(subRow);
-
-        deleteBtn.Click += (s, e) =>
-        {
-            DeleteRow(subathonValue, subRow);
-        };
-        return subRow;
-    }
-
-    private void DeleteRow(SubathonValue subathonValue, KoFiSubRow subRow)
-    {
-        using var db = _factory.CreateDbContext();
-
-        var dbRow = db.SubathonValues
-            .FirstOrDefault(x => x.Meta == subathonValue.Meta && x.EventType == subathonValue.EventType);
-
-        if (dbRow != null)
-        {
-            db.SubathonValues.Remove(dbRow);
-            db.SaveChanges();
-        }
-
-        _dynamicSubRows.Remove(subRow);
-        MembershipsPanel.Children.Remove(subRow.RowGrid);
-    }
-    
-    private void AddMembership_Click(object sender, RoutedEventArgs e)
-    {
-        var name = $"New {_dynamicSubRows.Count}";
-        var allNames = _dynamicSubRows.Select(x => x.NameBox.Text.Trim()).ToArray();
-        while (allNames.Contains(name)) name = $"New {name}";
-        allNames = _dynamicSubRows.Select(x => x.SubValue.Meta.Trim()).ToArray();
-        while (allNames.Contains(name)) name = $"New {name}";
-        var value = new SubathonValue
-        {
-            EventType = SubathonEventType.KoFiSub,
-            Meta = name,
-            Seconds = 0,
-            Points = 0
-        };
-        AddMembershipRow(value);
-    }
-    
-    private void EnsureUniqueName(List<KoFiSubRow> rows)
-    {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var row in rows)
-        {
-            string original = row.NameBox.Text.Trim();
-            string current = original;
-
-            while (!seen.Add(current.ToLower()))
-            {
-                current = "New " + current;
-            }
-            row.NameBox.Text = current;
-        }
-    }
-    
-    public override bool UpdateValueSettings(AppDbContext db)
-    {
-        bool hasUpdated = false;
-        var defaultSubValue =
-            db.SubathonValues.FirstOrDefault(sv =>
-                sv.EventType == SubathonEventType.KoFiSub && sv.Meta == "DEFAULT");
-        if (defaultSubValue != null && double.TryParse(KFSubDTextBox.Text, out var defaultSeconds) &&
-            !defaultSeconds.Equals(defaultSubValue.Seconds))
-        {
-            defaultSubValue.Seconds = defaultSeconds;
-            hasUpdated = true;
-        }
-
-        if (defaultSubValue != null && double.TryParse(KFSubDTextBox2.Text, out var defaultPoints) &&
-            !defaultPoints.Equals(defaultSubValue.Points))
-        {
-            defaultSubValue.Points = defaultPoints;
-            hasUpdated = true;
-        }
-
-        var tipValue =
-            db.SubathonValues.FirstOrDefault(sv =>
-                sv.EventType == SubathonEventType.KoFiDonation);
-        if (tipValue != null && double.TryParse(DonoBox.Text, out var tipSeconds) && !tipSeconds.Equals(tipValue.Seconds))
-        {
-            tipValue.Seconds = tipSeconds;
-            hasUpdated = true;
-        }
-
-        if (tipValue != null && double.TryParse(DonoBox2.Text, out var tipPoints) && !tipPoints.Equals(tipValue.Points))
-        {
-            tipValue.Points = tipPoints;
-            hasUpdated = true;
-        }
-
-        var removeRows = _dynamicSubRows
-            .Where(row =>string.IsNullOrWhiteSpace(row.NameBox.Text))
-            .ToList();
-        if (removeRows.Any()) 
-            hasUpdated = true;
-        foreach (var row in removeRows)
-            DeleteRow(row.SubValue, row);
-        
-        EnsureUniqueName(_dynamicSubRows);
-        
-        foreach (var subRow in _dynamicSubRows)
-        {
-            string meta = subRow.NameBox.Text.Trim();
-            if (string.IsNullOrWhiteSpace(meta))
-            {
-                DeleteRow(subRow.SubValue, subRow);
-                hasUpdated = true;
-                continue;
-            }
-            if (meta == "DEFAULT" )
-                continue;
-
-            if (!double.TryParse(subRow.TimeBox.Text, out double seconds))
-                seconds = 0;
-
-            if (!double.TryParse(subRow.PointsBox.Text, out double points))
-                points = 0;
-            
-#pragma warning disable CA1862
-            var existing = db.SubathonValues
-                .FirstOrDefault(sv => sv.EventType == SubathonEventType.KoFiSub 
-                                      && sv.Meta.ToLower() == meta.ToLower());
-#pragma warning restore CA1862           
-            if (existing != null)
-            {
-                existing.Seconds = seconds;
-                existing.Points = points;
-                subRow.SubValue = existing;
-                if (!seconds.Equals(existing.Seconds) || !points.Equals(existing.Points))
-                    hasUpdated = true;
-            }
-            else
-            {
-                subRow.SubValue.Meta = meta;
-                subRow.SubValue.Seconds = seconds;
-                subRow.SubValue.Points = points;
-                db.SubathonValues.Add(subRow.SubValue);
-                hasUpdated = true;
-            }
-        }
-        List<string> names = ["DEFAULT"];
-        foreach (var row in _dynamicSubRows)
-        {
-            string name = row.NameBox.Text.Trim();
-            names.Add(name);
-        }
-            
-        var dbRows   = db.SubathonValues.Where(x =>
-            !names.Contains(x.Meta) && x.EventType == SubathonEventType.KoFiSub).ToList();
-
-        if (dbRows.Count > 0)
-        {
-            db.SubathonValues.RemoveRange(dbRows);
-            hasUpdated = true;
-        }
-        return hasUpdated;
-    }
-    
-    public override void UpdateCurrencyBoxes(List<string> currencies, string selected)
-    {
-        CurrencyBox.ItemsSource = currencies;
-        CurrencyBox.SelectedItem = selected;
-    }
-
-    public override (string, string, TextBox?, TextBox?) GetValueBoxes(SubathonValue val)
-    {
-        string v = $"{val.Seconds}";
-        string p = $"{val.Points}";
-        TextBox? box = null;
-        TextBox? box2 = null;
-        switch (val.EventType)
-        {
-            case SubathonEventType.KoFiDonation:
-                box = DonoBox;
-                box2 = DonoBox2;
-                break;
-        }
-        return (v, p, box, box2);
-    }
-
-    private void OpenKoFiSetup_Click(object sender, RoutedEventArgs e)
-    {
-        OpenDiscussion();
-    }
+    private void OpenKoFiSetup_Click(object sender, RoutedEventArgs e) => OpenDiscussion();
 
     private void OpenDiscussion()
     {
@@ -398,53 +49,33 @@ public partial class KoFiSettings : SettingsControl
                 UseShellExecute = true
             });
         }
-        catch {/**/}
+        catch { /**/ }
     }
-    
+
     private async void CopyImportString_Click(object sender, RoutedEventArgs e)
     {
         string version = AppServices.AppVersion;
         if (!version.StartsWith('v') || version.Length > 16) version = "nightly";
-        string url =
-            $"https://github.com/WolfwithSword/SubathonManager/releases/download/{version}/SubathonManager_KoFi.sb";
+        string url = $"https://github.com/WolfwithSword/SubathonManager/releases/download/{version}/SubathonManager_KoFi.sb";
         try
         {
             using var http = new HttpClient();
             string content = await http.GetStringAsync(url);
+            if (string.IsNullOrWhiteSpace(content)) { OpenDiscussion(); return; }
 
-            if (string.IsNullOrWhiteSpace(content))
-            {
-                OpenDiscussion();
-                return;
-            }
-
-            try
-            {
-                var result = await UiUtils.UiUtils.TrySetClipboardTextAsync(content);
-                if (!result) return;
-                var button = sender as Button;
-                var originalContent = button!.Content;
-                button!.Content = "Copied!";
-                await Task.Delay(1500);
-                button!.Content = originalContent;
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogError(ex, $"Failed to copy KoFi StreamerBot import string.");
-            }
+            var result = await UiUtils.UiUtils.TrySetClipboardTextAsync(content);
+            if (!result) return;
+            var button = sender as Button;
+            var originalContent = button!.Content;
+            button.Content = "Copied!";
+            await Task.Delay(1500);
+            button.Content = originalContent;
         }
-        catch
-        {
-            OpenDiscussion();
-        }
+        catch { OpenDiscussion(); }
     }
-}
 
-public class KoFiSubRow
-{
-    public required SubathonValue SubValue { get; set; }
-    public required Wpf.Ui.Controls.TextBox NameBox { get; set; }
-    public required Wpf.Ui.Controls.TextBox TimeBox { get; set; }
-    public required Wpf.Ui.Controls.TextBox PointsBox { get; set; }
-    public required Grid RowGrid { get; set; }
+    protected internal override void LoadValues(AppDbContext db) { }
+    public override bool UpdateValueSettings(AppDbContext db) => false;
+    public override void UpdateCurrencyBoxes(List<string> currencies, string selected) { }
+    public override (string, string, TextBox?, TextBox?) GetValueBoxes(SubathonValue val) => ("", "", null, null);
 }

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiWebhookSettings.xaml
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiWebhookSettings.xaml
@@ -1,0 +1,69 @@
+<views:SettingsControl x:Class="SubathonManager.UI.Views.SettingsViews.External.KoFiWebhookSettings"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             xmlns:views="clr-namespace:SubathonManager.UI.Views">
+
+    <StackPanel>
+
+        <!-- Integration status row -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBlock Text="Status:" Width="80" VerticalAlignment="Center" FontSize="12"/>
+            <TextBlock x:Name="KoFiWebhookStatusText" Text="Disconnected" VerticalAlignment="Center" FontSize="12"/>
+        </StackPanel>
+
+        <!-- DevTunnels prerequisite status -->
+        <Border x:Name="TunnelStatusBorder" BorderThickness="1" CornerRadius="4" Padding="8,6"
+                BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                Background="{DynamicResource ControlFillColorDefaultBrush}"
+                Margin="0,0,0,10">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="DevTunnels:" Width="110" VerticalAlignment="Center" FontSize="12"/>
+                    <TextBlock x:Name="TunnelPrereqStatusText" Text="Not running"
+                               VerticalAlignment="Center" FontSize="12" Margin="0,0,12,0"/>
+                    <TextBlock Text="(Go to DevTunnels tab to set up)"
+                               x:Name="TunnelPrereqHint"
+                               VerticalAlignment="Center" FontSize="11"
+                               Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                </StackPanel>
+                <StackPanel x:Name="WebhookUrlRow" Orientation="Horizontal" Margin="0,6,0,0" Visibility="Collapsed">
+                    <TextBlock Text="Webhook URL:" Width="110" VerticalAlignment="Center" FontSize="12"/>
+                    <ui:TextBox x:Name="WebhookUrlBox" Width="420" Height="28" IsReadOnly="True"
+                                views:SettingsProperties.ExcludeFromUnsaved="True"
+                                FontSize="11" VerticalAlignment="Center"/>
+                    <ui:Button Content="Copy"
+                               Click="CopyWebhookUrl_Click"
+                               Width="56" Height="28" Padding="4,2"
+                               Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                               Margin="6,0,0,0"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- Configuration -->
+        <StackPanel Margin="0,2">
+            <StackPanel Orientation="Horizontal" Margin="0,4">
+                <TextBlock Text="Verification Token:" Width="160" VerticalAlignment="Center"
+                           ToolTip="The verification token from your Ko-fi webhook settings page. Found at Ko-fi → My Account → API → Webhooks."/>
+                <ui:TextBox x:Name="KoFiWebhookTokenBox" Width="360" Height="34"
+                            PlaceholderText="paste token here"
+                            ToolTip="Copy this from Ko-fi → My Account → API → Webhooks"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,4">
+                <TextBlock Text="Forward URL(s):" Width="160" VerticalAlignment="Center"
+                           ToolTip="Comma-separated list of URLs to forward the raw Ko-fi webhook to (e.g. StreamerBot). Leave blank to disable."/>
+                <ui:TextBox x:Name="KoFiWebhookForwardUrlsBox" Width="480" Height="34"
+                            PlaceholderText="http://localhost:7474/kofi, http://other-app/webhook"
+                            ToolTip="Separate multiple URLs with commas. The full webhook request is forwarded as-is."/>
+            </StackPanel>
+        </StackPanel>
+
+        <TextBlock Margin="0,10,0,0" FontSize="11" Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                   Text="Paste the Webhook URL above into Ko-fi → My Account → API → Webhooks. Timer values (seconds/points per donation or membership) are configured in the Ko-fi tab."/>
+
+    </StackPanel>
+
+</views:SettingsControl>

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiWebhookSettings.xaml
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiWebhookSettings.xaml
@@ -62,7 +62,7 @@
         </StackPanel>
 
         <TextBlock Margin="0,10,0,0" FontSize="11" Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                   Text="Paste the Webhook URL above into Ko-fi → My Account → API → Webhooks. Timer values (seconds/points per donation or membership) are configured in the Ko-fi tab."/>
+                   Text="Paste the Webhook URL above into Ko-fi → My Account → API → Webhooks."/>
 
     </StackPanel>
 

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiWebhookSettings.xaml
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiWebhookSettings.xaml
@@ -29,14 +29,15 @@
                                VerticalAlignment="Center" FontSize="11"
                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                 </StackPanel>
-                <StackPanel x:Name="WebhookUrlRow" Orientation="Horizontal" Margin="0,6,0,0" Visibility="Collapsed">
+                <StackPanel x:Name="WebhookUrlRow" Orientation="Horizontal" Margin="0,8,0,2" Visibility="Collapsed"
+                            MinHeight="36">
                     <TextBlock Text="Webhook URL:" Width="110" VerticalAlignment="Center" FontSize="12"/>
-                    <ui:TextBox x:Name="WebhookUrlBox" Width="420" Height="28" IsReadOnly="True"
+                    <ui:TextBox x:Name="WebhookUrlBox" Width="420" Height="34" IsReadOnly="True"
                                 views:SettingsProperties.ExcludeFromUnsaved="True"
                                 FontSize="11" VerticalAlignment="Center"/>
                     <ui:Button Content="Copy"
                                Click="CopyWebhookUrl_Click"
-                               Width="56" Height="28" Padding="4,2"
+                               Width="56" Height="34" Padding="4,2"
                                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
                                Margin="6,0,0,0"/>
                 </StackPanel>

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiWebhookSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiWebhookSettings.xaml.cs
@@ -1,0 +1,140 @@
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using SubathonManager.Core;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Models;
+using SubathonManager.Core.Objects;
+using SubathonManager.Data;
+using SubathonManager.Integration;
+using TextBox = System.Windows.Controls.TextBox;
+
+namespace SubathonManager.UI.Views.SettingsViews.External;
+
+public partial class KoFiWebhookSettings : SettingsControl
+{
+    private const string ConfigSection = "KoFi";
+
+    public KoFiWebhookSettings()
+    {
+        InitializeComponent();
+        Loaded += (_, _) =>
+        {
+            IntegrationEvents.ConnectionUpdated += UpdateStatus;
+            RegisterUnsavedChangeHandlers();
+            RefreshFromStoredState();
+        };
+
+        Unloaded += (_, _) =>
+        {
+            IntegrationEvents.ConnectionUpdated -= UpdateStatus;
+        };
+    }
+
+    // Called on every Loaded (incl. re-visits after switching tabs) so the UI
+    // always reflects the latest stored state without relying on in-memory service
+    // properties or a live event that may have fired while this control was detached.
+    private void RefreshFromStoredState()
+    {
+        // KoFiService owns its own connection entry (Status + public URL in Name).
+        UpdateStatus(Utils.GetConnection(SubathonEventSource.KoFiWebhook,
+            nameof(SubathonEventSource.KoFiWebhook)));
+
+        // DevTunnels prereq banner: read the last-known tunnel state from the shared dict.
+        UpdateStatus(Utils.GetConnection(SubathonEventSource.DevTunnels, "Tunnel"));
+    }
+
+    // ISettingsControl
+
+    internal override void UpdateStatus(IntegrationConnection? connection)
+    {
+        if (connection == null) return;
+
+        Dispatcher.Invoke(() =>
+        {
+            // KoFiService composes and owns the full public URL; we just display Name.
+            if (connection.Source == SubathonEventSource.KoFiWebhook)
+            {
+                Host.UpdateConnectionStatus(connection.Status, KoFiWebhookStatusText, null);
+                ApplyWebhookUrl(connection.Name);
+            }
+
+            // Tunnel prereq banner, driven by DevTunnels tunnel events.
+            if (connection is { Source: SubathonEventSource.DevTunnels, Service: "Tunnel" })
+                ApplyTunnelBanner(connection.Status, connection.Name);
+        });
+    }
+
+    private void ApplyWebhookUrl(string? url)
+    {
+        bool hasUrl = !string.IsNullOrWhiteSpace(url);
+        WebhookUrlRow.Visibility = hasUrl ? Visibility.Visible : Visibility.Collapsed;
+        if (hasUrl) WebhookUrlBox.Text = url!;
+    }
+
+    private void ApplyTunnelBanner(bool running, string? nameOrHint)
+    {
+        bool starting = nameOrHint == "(starting…)";
+        TunnelPrereqStatusText.Text = starting ? "Starting…" : (running ? "Running" : "Not running");
+        TunnelPrereqHint.Visibility = running ? Visibility.Collapsed : Visibility.Visible;
+        // The URL row is driven by the KoFiWebhook connection (Name field), not here.
+    }
+
+    // Config persistence
+
+    protected internal override void LoadValues(AppDbContext db)
+    {
+        SuppressUnsavedChanges(() =>
+        {
+            var config = AppServices.Provider.GetRequiredService<IConfig>();
+            KoFiWebhookTokenBox.Text = config.GetFromEncoded(ConfigSection, "VerificationToken", string.Empty) ?? string.Empty;
+            KoFiWebhookForwardUrlsBox.Text = config.Get(ConfigSection, "ForwardUrls", string.Empty) ?? string.Empty;
+        });
+    }
+
+    protected internal override bool UpdateConfigValueSettings()
+    {
+        var config = AppServices.Provider.GetRequiredService<IConfig>();
+        bool hasUpdated = false;
+        hasUpdated |= config.SetEncoded(ConfigSection, "VerificationToken", KoFiWebhookTokenBox.Text.Trim());
+        hasUpdated |= config.Set(ConfigSection, "ForwardUrls", KoFiWebhookForwardUrlsBox.Text.Trim());
+
+        if (hasUpdated)
+        {
+            // Restart KoFiService so it picks up the new token and (if enabled) triggers
+            // tunnel startup on demand. Fire-and-forget is fine here; the service
+            // broadcasts its own status events when it finishes starting.
+            _ = RestartKoFiAsync();
+        }
+
+        return hasUpdated;
+    }
+
+    private static async Task RestartKoFiAsync()
+    {
+        var sm = AppServices.Provider.GetRequiredService<Services.ServiceManager>();
+        await sm.StopAsync<KoFiService>();
+        await sm.StartAsync<KoFiService>();
+    }
+
+    public override bool UpdateValueSettings(AppDbContext db) => false;
+    public override void UpdateCurrencyBoxes(List<string> currencies, string selected) { }
+    public override (string, string, TextBox?, TextBox?) GetValueBoxes(SubathonValue val) => ("", "", null, null);
+
+    // Clipboard
+
+    private async void CopyWebhookUrl_Click(object sender, RoutedEventArgs e)
+    {
+        var url = WebhookUrlBox.Text;
+        if (string.IsNullOrWhiteSpace(url)) return;
+        var result = await UiUtils.UiUtils.TrySetClipboardTextAsync(url);
+        if (!result) return;
+        var btn = (sender as Wpf.Ui.Controls.Button)!;
+        var original = btn.Content;
+        btn.Content = "Copied!";
+        await Task.Delay(1500);
+        btn.Content = original;
+    }
+}

--- a/SubathonManager.UI/Views/SettingsViews/ExternalSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/ExternalSettings.xaml.cs
@@ -7,7 +7,8 @@ namespace SubathonManager.UI.Views.SettingsViews;
 public partial class ExternalSettings : SettingsGroupControl
 {
     protected override IEnumerable<SubathonEventSource> _eventSources =>
-        Enum.GetValues<SubathonEventSource>().Where(s => s.GetGroup() == SubathonSourceGroup.ExternalService)
+        Enum.GetValues<SubathonEventSource>()
+            .Where(s => s.GetGroup() == SubathonSourceGroup.ExternalService && s != SubathonEventSource.KoFiWebhook)
             .OrderBy(g => g.GetGroupLabelOrder());
 
     protected override StackPanel? GetSourceContents => SourceContents;
@@ -25,11 +26,11 @@ public partial class ExternalSettings : SettingsGroupControl
         switch (eventSource)
         {
             case SubathonEventSource.KoFi:
-                _settingsControls[eventSource] = new KoFiSettings();
+                _settingsControls[eventSource] = new KoFiCombinedSettings();
                 break;
             case SubathonEventSource.KoFiWebhook:
-                _settingsControls[eventSource] = new KoFiWebhookSettings();
-                break;
+                // merged into KoFi tab — return the shared instance without registering again
+                return _settingsControls.TryGetValue(SubathonEventSource.KoFi, out var kofi) ? kofi : null;
             case SubathonEventSource.DevTunnels:
                 _settingsControls[eventSource] = new DevTunnelsSettings();
                 break;
@@ -51,7 +52,7 @@ public partial class ExternalSettings : SettingsGroupControl
         _settingsControls.TryGetValue(source, out var control);
         // hc
         if (source == SubathonEventSource.KoFi)
-            ((KoFiSettings?) control)?.RefreshTierCombo();
+            ((KoFiCombinedSettings?) control)?.RefreshTierCombo();
         if (source == SubathonEventSource.External)
             ((ExternalServiceSettings?) control)?.RefreshTierCombo();
     }

--- a/SubathonManager.UI/Views/SettingsViews/ExternalSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/ExternalSettings.xaml.cs
@@ -27,6 +27,12 @@ public partial class ExternalSettings : SettingsGroupControl
             case SubathonEventSource.KoFi:
                 _settingsControls[eventSource] = new KoFiSettings();
                 break;
+            case SubathonEventSource.KoFiWebhook:
+                _settingsControls[eventSource] = new KoFiWebhookSettings();
+                break;
+            case SubathonEventSource.DevTunnels:
+                _settingsControls[eventSource] = new DevTunnelsSettings();
+                break;
             case SubathonEventSource.GoAffPro:
                 _settingsControls[eventSource] = new GoAffProSettings();
                 break;


### PR DESCRIPTION
This PR adds the full Ko-fi webhook integration using Azure DevTunnels, two new Ko-fi event types, and consolidates the existing Ko-fi settings into one combined tab.

Potentially closes #107

### Whats new

**`IWebhookIntegration` interface**

New interface added to give webhook-based integrations a consistent contract (`StartAsync`, `StopAsync`, `HandleWebhookAsync`, `WebhookPath`). The web server uses it to route inbound POST requests to the right handler. `KoFiService` is the first implementation.

**`DevTunnelsService`**

Ko-fi only allows a single webhook URL and it has to be publicly reachable, so DevTunnels handles the public tunnel. The service is shared across webhook integrations, not Ko-fi-specific, so future ones can reuse it without spinning up separate sessions.

On startup it probes CLI install state and login status and broadcasts both to the UI, but does not auto-start a tunnel. The tunnel only comes up on demand when a webhook integration that has a token configured calls `StartTunnelAsync`. If two integrations call in at the same time a semaphore makes sure only one session starts and the other reuses it. Background monitoring handles unexpected exits. The DevTunnels settings tab also has a manual Connect/Disconnect for testing outside of any specific integration, theoretically also supporting external access to websockets and the likes. If this should be prevented, headers could be checked for any proxying.

**`KoFiService`**

Implements `IWebhookIntegration` for Ko-fi. Uses the `KoFi.Client` NuGet package for payload parsing. Verifies the token from config, parses the event, raises `SubathonEventCreated`. The token is generally opt-in, but I've made it required, this can be adapted if needed but I blieve it's smarter to keep it this way. The raw payload is forwarded to any configured forward URLs before verification, so StreamerBot and similar tools still get it unmodified (still untested as I don't have StreamerBot installed/setup).

**New event types**

Two new `SubathonEventType` values:

- `KoFiShopOrder` direct product sales from the streamer's Ko-fi store
- `KoFiCommission` paid commissions offered via Ko-fi

Both use amount-based conversion (seconds/points per $1) since going per-item would require mapping individual product IDs which Ko-fi's webhook payload doesn't make easy enough to be practical, thought it is feasible using `shop_items[].direct_link_code`, I deemed it out of scope for this PR. 

DB seed entries added for both. No schema change, just new rows.

**Combined Ko-fi settings tab**

Socket and webhook settings are in a single Ko-fi tab with a radio toggle at the top to switch between modes. The selection persists based on config state: if a webhook verification token is saved, it opens on Webhook next time. Conversion settings (Donations, Shop Orders, Commissions, Memberships) sit below the toggle and apply regardless of which connection mode is active.

Implemented via composition: `KoFiSettings` covers socket-specific UI, `KoFiWebhookSettings` covers webhook UI, and `KoFiCombinedSettings` embeds both and owns the shared conversion rows.

This PR currently does not prevent events coming from both of the two implementations if both were to be setup.

### Tests

`DevTunnelsServiceTests`: CLI probe, login state, tunnel start/stop, idempotency, invalid stored tunnel ID reset
`KoFiServiceTests`: token validation, donation, subscription (new + renewal), shop order, commission, forward URL delivery.

### Note

The DevTunnels.Client library is getting a future DevTunnels.Client.Installer package that supports installation of the CLI tool itself and could later be integrated to support automatic setup for users.