### PR TITLE
feat: Subathon Cap, Stats Panel, OBS Integration, SecureStore

### DIFF
--- a/SubathonManager.Core/Enums/SubathonEventSource.cs
+++ b/SubathonManager.Core/Enums/SubathonEventSource.cs
@@ -35,7 +35,9 @@ public enum SubathonEventSource
     [EventSourceMeta(Description = "Dev Tunnels", SourceGroup = SubathonSourceGroup.ExternalService, SourceOrder=70, Visible=false, Order=120)]
     DevTunnels,
     [EventSourceMeta(Description="FourthWall", SourceGroup = SubathonSourceGroup.ExternalService, SourceOrder=62, Order=51)]
-    FourthWall
+    FourthWall,
+    [EventSourceMeta(Description="OBS Websocket", SourceGroup = SubathonSourceGroup.Unknown, SourceOrder=999, Order=999, Visible = false)]
+    OBS
 }
 
 [ExcludeFromCodeCoverage]

--- a/SubathonManager.Core/Models/SubathonData.cs
+++ b/SubathonManager.Core/Models/SubathonData.cs
@@ -28,17 +28,42 @@ public class SubathonData
     public double? MoneySum { get; set; } = 0; 
     
     public bool? ReversedTime { get; set; } = false;
+    
+    public DateTime? CapDateTime { get; set; } = null;
 
     public bool IsSubathonReversed()
     {
         return ReversedTime ?? false;
     }
 
+    public bool IsCapInEffect()
+    {
+        if (CapDateTime == null) return false;
+        long value = 0;
+        if (IsSubathonReversed())
+            value = MillisecondsCumulative + MillisecondsElapsed;
+        else
+            value = MillisecondsCumulative - MillisecondsElapsed;
+        return CapDateTime.Value < DateTime.Now + TimeSpan.FromMilliseconds(value);
+    }
+
     public long MillisecondsRemaining()
     {
+        long value = 0;
         if (IsSubathonReversed())
-            return MillisecondsCumulative + MillisecondsElapsed;
-        return MillisecondsCumulative - MillisecondsElapsed;
+            value = MillisecondsCumulative + MillisecondsElapsed;
+        else
+            value = MillisecondsCumulative - MillisecondsElapsed;
+
+        if (CapDateTime != null)
+        {
+            double timeUntilCap = 0;
+            var x = DateTime.Now;
+            if (CapDateTime.Value > x)
+                timeUntilCap = (CapDateTime.Value - x).TotalMilliseconds;
+            value = Math.Min(value, (long)timeUntilCap);
+        }
+        return value;
     }
 
     public TimeSpan TimeRemaining()

--- a/SubathonManager.Core/Security/DpapiSecureStorage.cs
+++ b/SubathonManager.Core/Security/DpapiSecureStorage.cs
@@ -1,0 +1,123 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SubathonManager.Core.Security.Interfaces;
+
+namespace SubathonManager.Core.Security;
+
+[System.Runtime.Versioning.SupportedOSPlatform("windows")]
+[ExcludeFromCodeCoverage]
+public sealed class DpapiSecureStorage : ISecureStorage
+{
+    private readonly string _filePath;
+    private readonly Lock _lock = new();
+    private Dictionary<string, string> _store;
+    private ILogger<ISecureStorage>? _logger;
+
+    public DpapiSecureStorage(ILogger<ISecureStorage>?  logger, string? filePath = null)
+    {
+        _logger = logger;
+        _filePath = filePath
+            ?? Path.GetFullPath(Path.Combine(string.Empty
+                , "data/secure_store.bin"));
+
+        _store = Load();
+    }
+
+    public bool Set(string key, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        bool hasUpdated = false;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            Delete(key);
+            return false;
+        }
+        if (string.Equals(GetOrDefault(key), value)) return false;
+        lock (_lock)
+        {
+            _store[key] = value;
+            Flush();
+            hasUpdated = true;
+        }
+
+        if (hasUpdated)
+        {
+            _logger?.LogInformation("[SecureStorage] Saved {Key}", key);
+        }
+        return hasUpdated;
+    }
+
+    public string? Get(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        lock (_lock)
+            return _store.GetValueOrDefault(key);
+    }
+    
+    public string? GetOrDefault(string key, string defaultValue = "")
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        lock (_lock)
+            return _store.GetValueOrDefault(key, defaultValue);
+    }
+
+    public bool Delete(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        lock (_lock)
+        {
+            if (_store.Remove(key))
+            {
+                Flush();
+                _logger?.LogInformation("[SecureStorage] Removed {Key}", key);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public bool Exists(string key)
+    {
+        lock (_lock)
+            return _store.ContainsKey(key);
+    }
+
+    private Dictionary<string, string> Load()
+    {
+        if (!File.Exists(_filePath))
+            return new Dictionary<string, string>();
+
+        try
+        {
+            var encrypted = File.ReadAllBytes(_filePath);
+            var plaintext = ProtectedData.Unprotect(
+                encrypted, null, DataProtectionScope.CurrentUser);
+
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(
+                Encoding.UTF8.GetString(plaintext))
+                ?? new Dictionary<string, string>();
+        }
+        catch (CryptographicException ex)
+        {
+            throw new InvalidOperationException(
+                "Secure store could not be decrypted. " +
+                "If you moved the app between user accounts, delete secure_store.bin and re-authenticate all services.",
+                ex);
+        }
+    }
+
+    private void Flush()
+    {
+        var json = JsonSerializer.Serialize(_store);
+        var plaintext = Encoding.UTF8.GetBytes(json);
+        var encrypted = ProtectedData.Protect(
+            plaintext, null, DataProtectionScope.CurrentUser);
+
+        var tmp = _filePath + ".tmp";
+        File.WriteAllBytes(tmp, encrypted);
+        File.Move(tmp, _filePath, overwrite: true);
+    }
+}

--- a/SubathonManager.Core/Security/Interfaces/ISecureStorage.cs
+++ b/SubathonManager.Core/Security/Interfaces/ISecureStorage.cs
@@ -1,0 +1,17 @@
+﻿namespace SubathonManager.Core.Security.Interfaces;
+
+public interface ISecureStorage
+{
+    /// <summary>Store or overwrite a value. Flushes to disk immediately.</summary>
+    bool Set(string key, string value);
+
+    /// <summary>Returns the value, or null if the key doesn't exist.</summary>
+    string? Get(string key);
+    
+    string? GetOrDefault(string key, string defaultValue);
+
+    /// <summary>Remove a key. No-op if it doesn't exist. Flushes to disk.</summary>
+    bool Delete(string key);
+
+    bool Exists(string key);
+}

--- a/SubathonManager.Core/Security/StorageKeys.cs
+++ b/SubathonManager.Core/Security/StorageKeys.cs
@@ -1,0 +1,18 @@
+﻿namespace SubathonManager.Core.Security;
+
+public static class StorageKeys
+{
+    public const string TwitchAccessToken = "SM.Twitch.AccessToken";
+    
+    public const string FourthWallAccessToken = "SM.FourthWall.AccessToken";
+    public const string FourthWallRefreshToken = "SM.FourthWall.RefreshToken";
+
+    public const string StreamLabsSocketToken  = "SM.StreamLabs.SocketToken";
+    public const string StreamElementsJwt = "SM.StreamElements.JWTToken";
+    public const string KoFiVerificationToken = "SM.KoFi.VerificationToken";
+    
+    public const string GoAffProEmail = "SM.GoAffPro.Email";
+    public const string GoAffProPassword = "SM.GoAffPro.Password";
+    
+    public const string OBSWebSocketPassword = "SM.OBS.WebSocket.Password";
+}

--- a/SubathonManager.Core/SubathonManager.Core.csproj
+++ b/SubathonManager.Core/SubathonManager.Core.csproj
@@ -13,6 +13,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
       <PackageReference Include="Updatum" Version="1.3.7" />
+      <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.6" />
     </ItemGroup>
 
 </Project>

--- a/SubathonManager.Data/DbContext.cs
+++ b/SubathonManager.Data/DbContext.cs
@@ -387,39 +387,39 @@ namespace SubathonManager.Data
                     .ExecuteUpdate(s =>
                         s.SetProperty(x => x.ReversedTime, false));
             }
-            var fontTypes = WidgetVariableTypeHelper.FontVariables.ToList();
-            var widgetsMissingFontTypes = db.Widgets
-                .Where(w => !fontTypes.All(ft => w.JsVariables.Any(v => v.Type == ft)))
-                .Include(w => w.JsVariables)
-                .ToList();
-            if (widgetsMissingFontTypes.Count > 0)
-            {
-                var newVars = new List<JsVariable>();
-                foreach (var widget in widgetsMissingFontTypes)
-                {
-                    var existingTypes = widget.JsVariables
-                        .Select(v => v.Type)
-                        .ToHashSet();
-
-                    foreach (var fontVar in fontTypes.Where(ft => !existingTypes.Contains(ft)))
-                    {
-                        newVars.Add(new JsVariable
-                        {
-                            WidgetId = widget.Id,
-                            Widget = widget,
-                            Type = fontVar,
-                            Name = $"{fontVar}s",
-                            Description = $"Custom font names to include from {fontVar}s, comma separated",
-                            Value = string.Empty
-                        });
-                    }
-                }
-                if (newVars.Count > 0)
-                {
-                    db.JsVariables.AddRange(newVars);
-                    db.SaveChanges();
-                }
-            }
+            // var fontTypes = WidgetVariableTypeHelper.FontVariables.ToList();
+            // var widgetsMissingFontTypes = db.Widgets
+            //     .Where(w => !fontTypes.All(ft => w.JsVariables.Any(v => v.Type == ft)))
+            //     .Include(w => w.JsVariables)
+            //     .ToList();
+            // if (widgetsMissingFontTypes.Count > 0)
+            // {
+            //     var newVars = new List<JsVariable>();
+            //     foreach (var widget in widgetsMissingFontTypes)
+            //     {
+            //         var existingTypes = widget.JsVariables
+            //             .Select(v => v.Type)
+            //             .ToHashSet();
+            //
+            //         foreach (var fontVar in fontTypes.Where(ft => !existingTypes.Contains(ft)))
+            //         {
+            //             newVars.Add(new JsVariable
+            //             {
+            //                 WidgetId = widget.Id,
+            //                 Widget = widget,
+            //                 Type = fontVar,
+            //                 Name = $"{fontVar}s",
+            //                 Description = $"Custom font names to include from {fontVar}s, comma separated",
+            //                 Value = string.Empty
+            //             });
+            //         }
+            //     }
+            //     if (newVars.Count > 0)
+            //     {
+            //         db.JsVariables.AddRange(newVars);
+            //         db.SaveChanges();
+            //     }
+            // }
         }
     }
 }

--- a/SubathonManager.Data/Migrations/20260428224540_AddCapDateTime.Designer.cs
+++ b/SubathonManager.Data/Migrations/20260428224540_AddCapDateTime.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SubathonManager.Data;
 
@@ -10,9 +11,11 @@ using SubathonManager.Data;
 namespace SubathonManager.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428224540_AddCapDateTime")]
+    partial class AddCapDateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.6");

--- a/SubathonManager.Data/Migrations/20260428224540_AddCapDateTime.cs
+++ b/SubathonManager.Data/Migrations/20260428224540_AddCapDateTime.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SubathonManager.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCapDateTime : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CapDateTime",
+                table: "SubathonDatas",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CapDateTime",
+                table: "SubathonDatas");
+        }
+    }
+}

--- a/SubathonManager.Data/WidgetEntityHelper.cs
+++ b/SubathonManager.Data/WidgetEntityHelper.cs
@@ -140,6 +140,27 @@ public class WidgetEntityHelper
                 db.JsVariables.Remove(variable);
             }
         }
+        
+        var existingFontTypesInDb = db.JsVariables
+            .Where(v => v.WidgetId == widget.Id && WidgetVariableTypeHelper.FontVariables.ToList().Contains(v.Type))
+            .Select(v => v.Type)
+            .Distinct()
+            .ToList();
+
+        var missingFontTypes = WidgetVariableTypeHelper.FontVariables
+            .Where(x => !existingFontTypesInDb.Contains(x))
+            .ToList();
+        foreach (var fontType in missingFontTypes)
+        {
+            db.JsVariables.Add(new JsVariable
+            {
+                WidgetId = widget.Id,
+                Type = fontType,
+                Name = $"{fontType}s",
+                Description = $"Custom font names to include from {fontType}s, comma separated",
+                Value = string.Empty
+            }); 
+        }
 
         db.SaveChanges();
     }

--- a/SubathonManager.Integration/FourthWallService.cs
+++ b/SubathonManager.Integration/FourthWallService.cs
@@ -19,10 +19,13 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
+// ReSharper disable NullableWarningSuppressionIsUsed
 
 namespace SubathonManager.Integration;
 
-public class FourthWallService(ILogger<FourthWallService>? logger, IConfig config, IHttpClientFactory httpClientFactory, DevTunnelsService devTunnels)
+public class FourthWallService(ILogger<FourthWallService>? logger, IConfig config, IHttpClientFactory httpClientFactory, DevTunnelsService devTunnels, ISecureStorage secureStorage)
     : IWebhookIntegration
 {
     private readonly string _configSection = "FourthWall";
@@ -38,11 +41,9 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
     internal readonly string _refreshURl = "https://oauth.subathonmanager.app/auth/fourthwall/refresh";
     
     internal Action<string> OpenBrowser = url => Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
-    private readonly string _tokenFile = Path.GetFullPath(Path.Combine(string.Empty
-        , "data/fw_token.json"));
-    
-    private string? AccessToken { get; set; }
-    private string? RefreshToken { get; set; }
+
+    private string? AccessToken => secureStorage.GetOrDefault(StorageKeys.FourthWallAccessToken, string.Empty);
+    private string? RefreshToken => secureStorage.GetOrDefault(StorageKeys.FourthWallRefreshToken, string.Empty);
     private string? ShopName { get; set; }
     
     public readonly Dictionary<string, string> MembershipNames = new();
@@ -50,21 +51,11 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
     private readonly FourthwallWebhookHandler _handler = new(signatureVerifier: new FourthwallWebhookSignatureVerifier());
     
     [ExcludeFromCodeCoverage]
-    private async Task<bool> CheckExpiry(string? token, CancellationToken ct = default)
+    private bool CheckExpiry()
     {
-        if (string.IsNullOrWhiteSpace(token))
-        {
-            if (!HasTokenFile()) return false;
-
-            var json = await File.ReadAllTextAsync(_tokenFile, ct);
-            var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-            AccessToken = data?["access_token"];
-            RefreshToken = data?["refresh_token"];
-            if (string.IsNullOrWhiteSpace(AccessToken)) return false;
-            token = AccessToken;
-        }
-
-        DateTime? expires = Utils.GetAccessTokenExpiry(token);
+        if (string.IsNullOrWhiteSpace(AccessToken)) return false;
+        
+        DateTime? expires = Utils.GetAccessTokenExpiry(AccessToken);
         if (expires == null) return false;
         bool isExpired =  DateTime.UtcNow >= expires.Value.AddSeconds(-60);
         return isExpired;
@@ -82,7 +73,7 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
                 return false;
             }
         }
-        else if (await CheckExpiry(AccessToken, ct))
+        else if (CheckExpiry())
         {
             var success = await StartOAuthRefreshAsync(ct);
             if (!success)
@@ -93,16 +84,13 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
             if (string.IsNullOrWhiteSpace(AccessToken)) return false;
         }
 
-        if (string.IsNullOrWhiteSpace(AccessToken) || await CheckExpiry(AccessToken, ct)) return false;
-        return true;
+        return !string.IsNullOrWhiteSpace(AccessToken) && !CheckExpiry();
     }
 
     public async Task StartAsync(CancellationToken ct = default)
     {
         IntegrationEvents.ConnectionUpdated += OnTunnelUpdated;
         
-        AccessToken = null;
-        RefreshToken = null;
         Utils.PendingOAuthCallback = null;
         bool enabled = HasTokenFile();
         
@@ -172,15 +160,17 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
             string? fullUrl = !string.IsNullOrWhiteSpace(tunnelConn.Name) && tunnelConn.Name != "(starting…)"
                 ? tunnelConn.Name.TrimEnd('/') + WebhookPath
                 : null;
-            WebhookConfigurationCreateRequest req = new WebhookConfigurationCreateRequest();
-            req.Url = fullUrl;
-            req.AllowedTypes = new List<WebhookConfigurationCreateRequest_allowedTypes?>()
+            WebhookConfigurationCreateRequest req = new WebhookConfigurationCreateRequest
             {
-                WebhookConfigurationCreateRequest_allowedTypes.ORDER_PLACED,
-                WebhookConfigurationCreateRequest_allowedTypes.DONATION,
-                WebhookConfigurationCreateRequest_allowedTypes.SUBSCRIPTION_PURCHASED,
-                WebhookConfigurationCreateRequest_allowedTypes.SUBSCRIPTION_CHANGED,
-                WebhookConfigurationCreateRequest_allowedTypes.GIFT_PURCHASE
+                Url = fullUrl,
+                AllowedTypes =
+                [
+                    WebhookConfigurationCreateRequest_allowedTypes.ORDER_PLACED,
+                    WebhookConfigurationCreateRequest_allowedTypes.DONATION,
+                    WebhookConfigurationCreateRequest_allowedTypes.SUBSCRIPTION_PURCHASED,
+                    WebhookConfigurationCreateRequest_allowedTypes.SUBSCRIPTION_CHANGED,
+                    WebhookConfigurationCreateRequest_allowedTypes.GIFT_PURCHASE
+                ]
             };
             var resp = await client.OpenApi.V10.Webhooks.PostAsync(req, cancellationToken: ct);
             if (resp == null || string.IsNullOrWhiteSpace(resp.Url))
@@ -227,16 +217,12 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
 
         if (!HasTokenFile()) return false;
 
-        var json = await File.ReadAllTextAsync(_tokenFile, ct);
-        var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-        var refreshToken = data?["refresh_token"];
-
-        if (string.IsNullOrWhiteSpace(refreshToken)) return false;
+        if (string.IsNullOrWhiteSpace(RefreshToken)) return false;
 
         using var client = httpClientFactory.CreateClient(nameof(FourthWallService));
         using var body = new FormUrlEncodedContent(new[]
         {
-            new KeyValuePair<string, string>("refresh_token", refreshToken),
+            new KeyValuePair<string, string>("refresh_token", RefreshToken),
         });
 
         var response = await client.PostAsync(_refreshURl, body, ct);
@@ -252,7 +238,7 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
         var tokens = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(responseJson);
 
         var newAccess  = tokens?.GetValueOrDefault("access_token").GetString();
-        var newRefresh = tokens?.GetValueOrDefault("refresh_token").GetString() ?? refreshToken;
+        var newRefresh = tokens?.GetValueOrDefault("refresh_token").GetString() ?? RefreshToken;
 
         if (string.IsNullOrWhiteSpace(newAccess))
         {
@@ -260,11 +246,8 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
             return false;
         }
 
-        AccessToken  = newAccess;
-        RefreshToken = newRefresh;
-
-        await File.WriteAllTextAsync(_tokenFile,
-            JsonSerializer.Serialize(new { access_token = AccessToken, refresh_token = RefreshToken }), ct);
+        secureStorage.Set(StorageKeys.FourthWallAccessToken, newAccess);
+        secureStorage.Set(StorageKeys.FourthWallRefreshToken, newRefresh);
 
         logger?.LogDebug("[FourthWall] Tokens refreshed successfully");
         return true;
@@ -276,11 +259,11 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
         Utils.PendingOAuthCallback = null;
         logger?.LogDebug("Opening FourthWall OAuth...");
         OpenBrowser(_oAuthURl);
-        (AccessToken, RefreshToken) = await WaitForProtocolCallbackAsync();   
+        var (newAccess, newRefresh) = await WaitForProtocolCallbackAsync();   
         if (!string.IsNullOrEmpty(AccessToken) || string.IsNullOrEmpty(RefreshToken))
         {
-            await File.WriteAllTextAsync(_tokenFile,
-                JsonSerializer.Serialize(new { access_token = AccessToken, refresh_token =  RefreshToken }));
+            secureStorage.Set(StorageKeys.FourthWallAccessToken, newAccess!);
+            secureStorage.Set(StorageKeys.FourthWallRefreshToken, newRefresh!);
         }
     }
     private async Task<(string?, string?)> WaitForProtocolCallbackAsync(CancellationToken ct = default)
@@ -301,15 +284,16 @@ public class FourthWallService(ILogger<FourthWallService>? logger, IConfig confi
 
     private bool HasTokenFile()
     {
-        return File.Exists(_tokenFile);
+        return secureStorage.Exists(StorageKeys.FourthWallAccessToken) &&
+               secureStorage.Exists(StorageKeys.FourthWallRefreshToken)
+               && !string.IsNullOrWhiteSpace(AccessToken) && !string.IsNullOrWhiteSpace(RefreshToken);
     }
 
     [ExcludeFromCodeCoverage]
     public void RevokeTokenFile()
     {
-        if (HasTokenFile()) File.Delete(_tokenFile);
-        AccessToken = string.Empty;
-        RefreshToken = string.Empty;
+        secureStorage.Delete(StorageKeys.FourthWallAccessToken);
+        secureStorage.Delete(StorageKeys.FourthWallRefreshToken);
     }
 
     [ExcludeFromCodeCoverage]

--- a/SubathonManager.Integration/GoAffProService.cs
+++ b/SubathonManager.Integration/GoAffProService.cs
@@ -11,13 +11,15 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Services;
 
 // ReSharper disable NullableWarningSuppressionIsUsed
 
 namespace SubathonManager.Integration;
 
-public class GoAffProService(ILogger<GoAffProService>? logger, IConfig config, TimerService? timerService = null) : IDisposable, IAppService
+public class GoAffProService(ILogger<GoAffProService>? logger, IConfig config, ISecureStorage secureStorage, TimerService? timerService = null) : IDisposable, IAppService
 {
     private bool _disposed = false;
 
@@ -28,6 +30,9 @@ public class GoAffProService(ILogger<GoAffProService>? logger, IConfig config, T
     internal Uri Endpoint = new Uri("https://api.goaffpro.com/v1/", UriKind.Absolute);
     internal int MaxRetries = 20;
 
+    private string? Email => secureStorage.GetOrDefault(StorageKeys.GoAffProEmail, string.Empty);
+    private string? Password => secureStorage.GetOrDefault(StorageKeys.GoAffProPassword, string.Empty);
+
 
     private HashSet<int> _siteIds = new();
 
@@ -35,11 +40,8 @@ public class GoAffProService(ILogger<GoAffProService>? logger, IConfig config, T
     {
         await StopAsync(ct);
         timerService?.Register("goaffpro-auth-check", TimeSpan.FromHours(48), ReconnectCheck);
-
-        var email = config.GetFromEncoded(_configSection, "Email",string.Empty);
-        var password = config.GetFromEncoded(_configSection, "Password", string.Empty);
-
-        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password)) return;
+        
+        if (string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Password)) return;
         _siteIds.Clear();
 
         try
@@ -51,8 +53,8 @@ public class GoAffProService(ILogger<GoAffProService>? logger, IConfig config, T
                     Timeout = TimeSpan.FromSeconds(30),
                     BaseUrl = Endpoint
                 },
-                email: email,
-                password: password, cancellationToken: ct);
+                email: Email,
+                password: Password, cancellationToken: ct);
             
             IntegrationConnection conn = new IntegrationConnection
             {

--- a/SubathonManager.Integration/KoFiService.cs
+++ b/SubathonManager.Integration/KoFiService.cs
@@ -11,10 +11,12 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 
 namespace SubathonManager.Integration;
 
-public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClientFactory httpClientFactory, DevTunnelsService devTunnels)
+public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClientFactory httpClientFactory, DevTunnelsService devTunnels, ISecureStorage secureStorage)
     : IWebhookIntegration
 {
     private readonly string _configSection = "KoFi";
@@ -35,7 +37,7 @@ public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClie
     {
         IntegrationEvents.ConnectionUpdated += OnTunnelUpdated;
 
-        var token = config.GetFromEncoded(_configSection, "VerificationToken", string.Empty);
+        var token = secureStorage.Get(StorageKeys.KoFiVerificationToken); // config.GetFromEncoded(_configSection, "VerificationToken", string.Empty);
         bool enabled = !string.IsNullOrWhiteSpace(token);
 
         if (enabled)
@@ -70,7 +72,7 @@ public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClie
     private void OnTunnelUpdated(IntegrationConnection connection)
     {
         if (connection is not { Source: SubathonEventSource.DevTunnels, Service: "Tunnel" }) return;
-        var token = config.GetFromEncoded(_configSection, "VerificationToken", string.Empty);
+        var token = secureStorage.Get(StorageKeys.KoFiVerificationToken);
         bool enabled = !string.IsNullOrWhiteSpace(token);
         BroadcastStatus(enabled, connection.Status ? connection.Name : null);
     }
@@ -103,7 +105,7 @@ public class KoFiService(ILogger<KoFiService>? logger, IConfig config, IHttpClie
         // forwarded service (e.g. StreamerBot) needs the same unmodified payload.
         await ForwardRequestAsync(rawBody, headers, ct);
 
-        var token = config.GetFromEncoded(_configSection, "VerificationToken", string.Empty);
+        var token = secureStorage.Get(StorageKeys.KoFiVerificationToken);
         if (string.IsNullOrWhiteSpace(token))
         {
             logger?.LogWarning("[Ko-Fi] Received webhook but no verification token is configured");

--- a/SubathonManager.Integration/OBSService.cs
+++ b/SubathonManager.Integration/OBSService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using OBSWebsocketDotNet;
 using OBSWebsocketDotNet.Communication;
 using SubathonManager.Core;
@@ -6,6 +7,9 @@ using SubathonManager.Core.Enums;
 using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
+// ReSharper disable NullableWarningSuppressionIsUsed
 
 namespace SubathonManager.Integration;
 
@@ -13,16 +17,18 @@ public class OBSService : IAppService
 {
     private readonly ILogger? _logger;
     private readonly IConfig _config;
+    private readonly ISecureStorage _secureStorage;
     private readonly OBSWebsocket _obs = new();
     private readonly Utils.ServiceReconnectState _reconnectState =
         new(TimeSpan.FromSeconds(5), maxRetries: 1000, maxBackoff: TimeSpan.FromMinutes(5));
 
     public bool Connected => _obs.IsConnected;
 
-    public OBSService(ILogger<OBSService>? logger, IConfig config)
+    public OBSService(ILogger<OBSService>? logger, IConfig config, ISecureStorage secureStorage)
     {
         _logger = logger;
         _config = config;
+        _secureStorage = secureStorage;
 
         _obs.Connected += OnConnected;
         _obs.Disconnected += OnDisconnected;
@@ -57,7 +63,7 @@ public class OBSService : IAppService
     {
         var host = _config.Get("OBS", "Host", "localhost")!;
         var port = _config.Get("OBS", "Port", "4455")!;
-        var password = _config.GetFromEncoded("OBS", "Password", "")!;
+        var password = _secureStorage.GetOrDefault(StorageKeys.OBSWebSocketPassword, string.Empty);
 
         if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(port)) return;
 
@@ -109,7 +115,8 @@ public class OBSService : IAppService
             _ = Task.Run(ReconnectWithBackoffAsync);
         }
     }
-
+    
+    [ExcludeFromCodeCoverage]
     private async Task ReconnectWithBackoffAsync()
     {
         if (!await _reconnectState.Lock.WaitAsync(0)) return;
@@ -169,7 +176,7 @@ public class OBSService : IAppService
         bool hasUpdated = false;
         hasUpdated |= _config.Set("OBS", "Host", host);
         hasUpdated |= _config.Set("OBS", "Port", port);
-        hasUpdated |= _config.SetEncoded("OBS", "Password", password);
+        hasUpdated |= _secureStorage.Set(StorageKeys.OBSWebSocketPassword, password);
         if (hasUpdated && forceSave)
             _config.Save();
         return hasUpdated;
@@ -180,7 +187,7 @@ public class OBSService : IAppService
         return (
             _config.Get("OBS", "Host", "localhost")!,
             _config.Get("OBS", "Port", "4455")!,
-            _config.GetFromEncoded("OBS", "Password", "")!
+            _secureStorage.GetOrDefault(StorageKeys.OBSWebSocketPassword, string.Empty)!
         );
     }
 

--- a/SubathonManager.Integration/OBSService.cs
+++ b/SubathonManager.Integration/OBSService.cs
@@ -1,0 +1,249 @@
+﻿using Microsoft.Extensions.Logging;
+using OBSWebsocketDotNet;
+using OBSWebsocketDotNet.Communication;
+using SubathonManager.Core;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Objects;
+
+namespace SubathonManager.Integration;
+
+public class OBSService : IAppService
+{
+    private readonly ILogger? _logger;
+    private readonly IConfig _config;
+    private readonly OBSWebsocket _obs = new();
+    private readonly Utils.ServiceReconnectState _reconnectState =
+        new(TimeSpan.FromSeconds(5), maxRetries: 1000, maxBackoff: TimeSpan.FromMinutes(5));
+
+    public bool Connected => _obs.IsConnected;
+
+    public OBSService(ILogger<OBSService>? logger, IConfig config)
+    {
+        _logger = logger;
+        _config = config;
+
+        _obs.Connected += OnConnected;
+        _obs.Disconnected += OnDisconnected;
+    }
+    
+    public List<string> GetScenes()
+    {
+        return _obs.GetSceneList().Scenes
+            .Select(s => s.Name)
+            .ToList();
+    }
+
+    public string GetCurrentScene()
+    {
+        return _obs.GetCurrentProgramScene();
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        _ = Task.Run(TryConnect, cancellationToken);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        _reconnectState.Cts?.Cancel();
+        if (_obs.IsConnected) _obs.Disconnect();
+        return Task.CompletedTask;
+    }
+
+    public void TryConnect()
+    {
+        var host = _config.Get("OBS", "Host", "localhost")!;
+        var port = _config.Get("OBS", "Port", "4455")!;
+        var password = _config.GetFromEncoded("OBS", "Password", "")!;
+
+        if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(port)) return;
+
+        try
+        {
+            var url = $"ws://{host}:{port}";
+            _obs.ConnectAsync(url, password);
+        }
+        catch (Exception ex)
+        {
+            if (_reconnectState.Retries < 3)
+                _logger?.LogWarning(ex, "[OBSService] Connection attempt failed");
+            else
+            {
+                _logger?.LogDebug(ex, "[OBSService] Connection attempt failed");
+            }
+        }
+    }
+
+    private void OnConnected(object? sender, EventArgs e)
+    {
+        _logger?.LogInformation("[OBSService] Connected");
+        _reconnectState.Reset();
+        _reconnectState.Cts?.Cancel();
+
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Source = SubathonEventSource.OBS,
+            Service = "OBS",
+            Name = "WebSocket",
+            Status = true
+        });
+    }
+
+    private void OnDisconnected(object? sender, ObsDisconnectionInfo e)
+    {
+
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Source = SubathonEventSource.OBS,
+            Service = "OBS",
+            Name = "WebSocket",
+            Status = false
+        });
+
+        if (_reconnectState.Retries < 2)
+        {
+            _logger?.LogWarning("[OBSService] Disconnected: {Reason}", e.DisconnectReason ?? "Not Running?");
+            _ = Task.Run(ReconnectWithBackoffAsync);
+        }
+    }
+
+    private async Task ReconnectWithBackoffAsync()
+    {
+        if (!await _reconnectState.Lock.WaitAsync(0)) return;
+
+        try
+        {
+            _reconnectState.Cts?.Cancel();
+            _reconnectState.Cts = new CancellationTokenSource();
+            var token = _reconnectState.Cts.Token;
+
+            var host = _config.Get("OBS", "Host", "")!;
+            var port = _config.Get("OBS", "Port", "")!;
+            if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(port)) return;
+
+            while (!token.IsCancellationRequested && !_obs.IsConnected)
+            {
+                if (_reconnectState.Retries >= _reconnectState.MaxRetries)
+                {
+                    _logger?.LogError("[OBSService] Max reconnect retries reached");
+                    return;
+                }
+
+                _reconnectState.Retries++;
+                var delay = _reconnectState.Backoff;
+
+                if (_reconnectState.Retries < 3 || _reconnectState.Retries % 10 == 0)
+                {
+                    _logger?.LogDebug("[OBSService] Reconnect attempt {N} in {Delay}s",
+                        _reconnectState.Retries, delay.TotalSeconds);
+                }
+
+                try
+                {
+                    await Task.Delay(delay, token);
+                    if (!_obs.IsConnected) TryConnect();
+                }
+                catch (OperationCanceledException) { return; }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "[OBSService] Reconnect error");
+                }
+
+                _reconnectState.Backoff = TimeSpan.FromMilliseconds(
+                    Math.Min(
+                        _reconnectState.Backoff.TotalMilliseconds * 2,
+                        _reconnectState.MaxBackoff.TotalMilliseconds));
+            }
+        }
+        finally
+        {
+            _reconnectState.Lock.Release();
+        }
+    }
+
+    public bool SaveConfig(string host, string port, string password, bool forceSave = false)
+    {
+        bool hasUpdated = false;
+        hasUpdated |= _config.Set("OBS", "Host", host);
+        hasUpdated |= _config.Set("OBS", "Port", port);
+        hasUpdated |= _config.SetEncoded("OBS", "Password", password);
+        if (hasUpdated && forceSave)
+            _config.Save();
+        return hasUpdated;
+    }
+
+    public (string host, string port, string password) GetConfig()
+    {
+        return (
+            _config.Get("OBS", "Host", "localhost")!,
+            _config.Get("OBS", "Port", "4455")!,
+            _config.GetFromEncoded("OBS", "Password", "")!
+        );
+    }
+
+    public async Task AddBrowserSource(
+        string sourceName, string url, int width, int height,
+        string sceneName, bool fitToScreen = false)
+    {
+        if (!_obs.IsConnected)
+            throw new InvalidOperationException("OBS is not connected");
+
+        var existingInputs = _obs.GetInputList();
+        string finalName = sourceName;
+        int count = 1;
+        while (existingInputs.Any(i => i.InputName == finalName))
+            finalName = $"{sourceName} ({count++})";
+
+        var settings = new Newtonsoft.Json.Linq.JObject
+        {
+            ["url"] = url,
+            ["width"] = width,
+            ["height"] = height,
+            ["reroute_audio"] = false,
+            ["restart_when_active"] = false,
+            ["shutdown"] = false,
+            ["is_local_file"] = false,
+            ["css"] = "body { background-color: rgba(0, 0, 0, 0); margin: 0px auto; overflow: hidden; }"
+        };
+
+        _obs.CreateInput(sceneName, finalName, "browser_source", settings, true);
+        await Task.Delay(500);
+        if (fitToScreen)
+        {
+            try
+            {
+                var sceneItems = _obs.GetSceneItemList(sceneName);
+                var item = sceneItems.FirstOrDefault(si => si.SourceName == finalName);
+                if (item != null)
+                {
+                    var videoSettings = _obs.GetVideoSettings();
+            
+                    var transformRequest = new Newtonsoft.Json.Linq.JObject
+                    {
+                        ["sceneName"] = sceneName,
+                        ["sceneItemId"] = item.ItemId,
+                        ["sceneItemTransform"] = new Newtonsoft.Json.Linq.JObject
+                        {
+                            ["boundsType"] = "OBS_BOUNDS_SCALE_INNER",
+                            ["boundsWidth"] = (double)videoSettings.BaseWidth,
+                            ["boundsHeight"] = (double)videoSettings.BaseHeight,
+                            ["boundsAlignment"] = 0,
+                            ["positionX"] = 0.0,
+                            ["positionY"] = 0.0
+                        }
+                    };
+                    _obs.SendRequest("SetSceneItemTransform", transformRequest);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "[OBS] SetSceneItemTransform failed");
+            }
+        }
+    }
+    
+    
+}

--- a/SubathonManager.Integration/StreamElementsService.cs
+++ b/SubathonManager.Integration/StreamElementsService.cs
@@ -9,10 +9,13 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 
 namespace SubathonManager.Integration;
 
-public class StreamElementsService : IAppService
+public class StreamElementsService(ILogger<StreamElementsService>? logger, IConfig config, ISecureStorage secureStorage)
+    : IAppService
 {
 
     private Func<StreamElementsClient> ClientFactory { get; set; } 
@@ -20,19 +23,11 @@ public class StreamElementsService : IAppService
     
     private StreamElementsClient? _client;
     public bool Connected { get; private set; } = false;
-    private string _jwtToken = "";
+    private string? JwtToken => secureStorage.GetOrDefault(StorageKeys.StreamElementsJwt, string.Empty);
     private bool _hasAuthError = false;
     private readonly Utils.ServiceReconnectState _reconnectState =
         new(TimeSpan.FromSeconds(2), maxRetries: 50, maxBackoff: TimeSpan.FromMinutes(5));
     
-    private readonly ILogger? _logger;
-    private readonly IConfig _config;
-
-    public StreamElementsService(ILogger<StreamElementsService>? logger, IConfig config)
-    {
-        _logger = logger;
-        _config = config;
-    }
 
     public Task StartAsync(CancellationToken cancellationToken = default)
     {
@@ -51,8 +46,7 @@ public class StreamElementsService : IAppService
         _client = ClientFactory();
         _hasAuthError = false;
         Connected = false;
-        GetJwtFromConfig();
-        if (_jwtToken.Equals(string.Empty)) return false;
+        if (string.IsNullOrWhiteSpace(JwtToken)) return false;
         
         if (_client != null)
         {
@@ -67,36 +61,29 @@ public class StreamElementsService : IAppService
         _client.OnTip += _OnTip;
         _client.OnDisconnected += _OnDisconnected;
         _client.OnAuthenticationFailure += _OnAuthenticateError;
-        _client.Connect(_jwtToken);
+        _client.Connect(JwtToken);
         return true;
     }
 
     public bool IsTokenEmpty()
     {
-        return string.IsNullOrEmpty(_jwtToken);
+        return !secureStorage.Exists(StorageKeys.StreamElementsJwt) || string.IsNullOrWhiteSpace(JwtToken);
     }
 
-    public void SetJwtToken(string token)
+    public bool SetJwtToken(string token)
     {
-        _jwtToken = token;
-        if (_config.Set("StreamElements", "JWT", token))
-            _config.Save();
+        return secureStorage.Set(StorageKeys.StreamElementsJwt, token);
     }
-
-    private void GetJwtFromConfig()
-    {
-        _jwtToken = _config.Get("StreamElements", "JWT", "")!;
-    }
-
+    
     private void _OnConnected(object? sender, EventArgs e)
     {
-        _logger?.LogInformation("[StreamElementsService] Connected");
+        logger?.LogInformation("[StreamElementsService] Connected");
         _reconnectState.Reset();
         _reconnectState.Cts?.Cancel();
     }
     private void _OnDisconnected(object? sender, EventArgs e)
     {
-        _logger?.LogWarning("[StreamElementsService] Disconnected");
+        logger?.LogWarning("[StreamElementsService] Disconnected");
         Connected = false;
          
         IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
@@ -139,7 +126,7 @@ public class StreamElementsService : IAppService
                         message,
                         DateTime.Now.ToLocalTime());
 
-                    _logger?.LogError(message);
+                    logger?.LogError(message);
                     return;
                 }
 
@@ -147,7 +134,7 @@ public class StreamElementsService : IAppService
 
                 var delay = _reconnectState.Backoff;
 
-                _logger?.LogWarning(
+                logger?.LogWarning(
                     "[StreamElementsService] Reconnect attempt {Attempt}/{Max} in {Delay}s",
                     _reconnectState.Retries,
                     _reconnectState.MaxRetries,
@@ -159,7 +146,7 @@ public class StreamElementsService : IAppService
 
                     if (!Connected && !_hasAuthError && _client != null)
                     {
-                        _client.Connect(_jwtToken);
+                        _client.Connect(JwtToken);
                     }
                 }
                 catch (OperationCanceledException)
@@ -169,7 +156,7 @@ public class StreamElementsService : IAppService
                 catch (Exception ex)
                 {
                     string message = $"StreamElements Disconnected with an error. Could not auto-reconnect. {ex.Message}";
-                    _logger?.LogWarning(ex, message);
+                    logger?.LogWarning(ex, message);
                     ErrorMessageEvents.RaiseErrorEvent("ERROR", nameof(SubathonEventSource.StreamElements), 
                                        message, DateTime.Now.ToLocalTime());
                 }
@@ -189,7 +176,7 @@ public class StreamElementsService : IAppService
 
     private void _OnAuthenticated(object? sender, Authenticated e)
     {
-        _logger?.LogDebug($"[StreamElementsService] Authenticated");
+        logger?.LogDebug($"[StreamElementsService] Authenticated");
         Connected = true;
         _hasAuthError = false;
 
@@ -206,7 +193,7 @@ public class StreamElementsService : IAppService
 
     private void _OnAuthenticateError(object? sender, EventArgs e)
     {
-        _logger?.LogError("[StreamElementsService] Authentication Error");
+        logger?.LogError("[StreamElementsService] Authentication Error");
         Connected = false;
         _hasAuthError = true;
         _reconnectState.Cts?.Cancel();   
@@ -253,7 +240,17 @@ public class StreamElementsService : IAppService
         }
         catch (Exception ex)
         {
-            _logger?.LogWarning(ex, "[StreamElementsService] Disconnection Error");
+            logger?.LogWarning(ex, "[StreamElementsService] Disconnection Error");
+        }
+        finally
+        {
+            IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+            {
+                Source = SubathonEventSource.StreamElements,
+                Service = "Socket",
+                Name = "User",
+                Status = false
+            });
         }
     }
 

--- a/SubathonManager.Integration/StreamElementsService.cs
+++ b/SubathonManager.Integration/StreamElementsService.cs
@@ -14,7 +14,7 @@ using SubathonManager.Core.Security.Interfaces;
 
 namespace SubathonManager.Integration;
 
-public class StreamElementsService(ILogger<StreamElementsService>? logger, IConfig config, ISecureStorage secureStorage)
+public class StreamElementsService(ILogger<StreamElementsService>? logger, ISecureStorage secureStorage)
     : IAppService
 {
 

--- a/SubathonManager.Integration/StreamLabsService.cs
+++ b/SubathonManager.Integration/StreamLabsService.cs
@@ -9,6 +9,8 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 
 namespace SubathonManager.Integration;
 
@@ -16,19 +18,21 @@ public class StreamLabsService : IAppService
 {
     internal Func<string, IStreamlabsClient> ClientFactory;
     private IStreamlabsClient? _client;
-    private string _secretToken = "";
     public bool Connected { get; private set; } = false;
 
     private readonly ILogger? _logger;
     private readonly IConfig _config;
+    private readonly ISecureStorage _secureStorage;
 
     internal string BaseUrl = "https://sockets.streamlabs.com";
+    private string? SecretToken => _secureStorage.GetOrDefault(StorageKeys.StreamLabsSocketToken, string.Empty);
 
-    public StreamLabsService(ILogger<StreamLabsService>? logger, IConfig config)
+    public StreamLabsService(ILogger<StreamLabsService>? logger, IConfig config, ISecureStorage secureStorage)
     {
         _logger = logger;
         _config = config;
-        
+        _secureStorage = secureStorage;
+
         ClientFactory = token =>
         {
             var options = new OptionsWrapper<StreamlabsOptions>(
@@ -51,8 +55,6 @@ public class StreamLabsService : IAppService
     // todo cleanup all names in test for inits
     public async Task<bool> InitClientAsync()
     {
-        GetTokenFromConfig();
-        
         IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
         {
             Source = SubathonEventSource.StreamLabs,
@@ -61,7 +63,7 @@ public class StreamLabsService : IAppService
             Status = false
         });
         
-        if (_secretToken.Equals(string.Empty))
+        if (string.IsNullOrWhiteSpace(SecretToken))
         {
             Connected = false; 
             return false;
@@ -69,7 +71,7 @@ public class StreamLabsService : IAppService
 
         if (_client != null) await DisconnectAsync();
         
-        _client = ClientFactory(_secretToken);
+        _client = ClientFactory(SecretToken);
         _client.OnDonation += OnDonation;
         try
         {
@@ -94,21 +96,14 @@ public class StreamLabsService : IAppService
         return Connected;
     }
     
-    private void GetTokenFromConfig()
-    {
-        _secretToken = _config.Get("StreamLabs", "SocketToken", string.Empty)!;
-    }  
-    
     public bool IsTokenEmpty()
     {
-        return string.IsNullOrEmpty(_secretToken);
+        return !_secureStorage.Exists(StorageKeys.StreamLabsSocketToken) || string.IsNullOrWhiteSpace(SecretToken);
     }
-    
-    public void SetSocketToken(string token)
+
+    public bool SetSocketToken(string token)
     {
-        _secretToken = token;
-        if (_config.Set("StreamLabs", "SocketToken", token))
-            _config.Save();
+       return _secureStorage.Set(StorageKeys.StreamLabsSocketToken, token);
     }
     
     private void OnDonation(object? o, DonationMessage message)

--- a/SubathonManager.Integration/StreamLabsService.cs
+++ b/SubathonManager.Integration/StreamLabsService.cs
@@ -21,16 +21,14 @@ public class StreamLabsService : IAppService
     public bool Connected { get; private set; } = false;
 
     private readonly ILogger? _logger;
-    private readonly IConfig _config;
     private readonly ISecureStorage _secureStorage;
 
     internal string BaseUrl = "https://sockets.streamlabs.com";
     private string? SecretToken => _secureStorage.GetOrDefault(StorageKeys.StreamLabsSocketToken, string.Empty);
 
-    public StreamLabsService(ILogger<StreamLabsService>? logger, IConfig config, ISecureStorage secureStorage)
+    public StreamLabsService(ILogger<StreamLabsService>? logger, ISecureStorage secureStorage)
     {
         _logger = logger;
-        _config = config;
         _secureStorage = secureStorage;
 
         ClientFactory = token =>

--- a/SubathonManager.Integration/SubathonManager.Integration.csproj
+++ b/SubathonManager.Integration/SubathonManager.Integration.csproj
@@ -17,6 +17,7 @@
       <PackageReference Include="KoFi.Client" Version="0.1.1-dev1" />
       <PackageReference Include="Agash.YTLiveChat" Version="4.2.0-dev3" />
       <PackageReference Include="GoAffPro.Client" Version="0.4.0" />
+      <PackageReference Include="obs-websocket-dotnet" Version="5.0.1" />
       <PackageReference Include="StreamElements.WebSocket" Version="1.0.2" />
       <PackageReference Include="Streamlabs.SocketClient" Version="3.0.0" />
       <PackageReference Include="TwitchLib.Api" Version="3.9.0" />

--- a/SubathonManager.Integration/TwitchService.cs
+++ b/SubathonManager.Integration/TwitchService.cs
@@ -144,7 +144,7 @@ public class TwitchService(ILogger<TwitchService>? logger, IConfig config, ISecu
         Utils.PendingOAuthCallback = null;
         logger?.LogDebug("Opening Twitch OAuth...");
         OpenBrowser(_oAuthURl);
-        var token = await WaitForProtocolCallbackAsync();   
+        var token = await WaitForProtocolCallbackAsync();
         if (!string.IsNullOrWhiteSpace(token))
         {
             secureStorage.Set(StorageKeys.TwitchAccessToken, token);
@@ -160,7 +160,7 @@ public class TwitchService(ILogger<TwitchService>? logger, IConfig config, ISecu
             if (cb?.Provider == "twitch" && !string.IsNullOrEmpty(cb.AccessToken))
             {
                 logger?.LogInformation("Twitch OAuth Callback received");
-                var token = cb.RefreshToken;
+                var token = cb.AccessToken;
                 Utils.PendingOAuthCallback = null;
                 return token;
             }

--- a/SubathonManager.Integration/TwitchService.cs
+++ b/SubathonManager.Integration/TwitchService.cs
@@ -1,8 +1,5 @@
 ﻿using System.Diagnostics;
-using System.Net;
-using System.Text.Json;
 using System.Diagnostics.CodeAnalysis;
-using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
 using TwitchLib.Api;
 using TwitchLib.Api.Core.Enums;
@@ -17,6 +14,8 @@ using SubathonManager.Core.Enums;
 using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Services;
 using TwitchLib.Client.Events;
 using TwitchLib.EventSub.Core.EventArgs.Stream;
@@ -25,7 +24,8 @@ using TwitchLib.EventSub.Websockets.Core.EventArgs;
 
 namespace SubathonManager.Integration;
 
-public class TwitchService : IDisposable, IAppService
+public class TwitchService(ILogger<TwitchService>? logger, IConfig config, ISecureStorage secureStorage)
+    : IDisposable, IAppService
 {
     private TwitchAPI? _api;
     private TwitchClient? _chat;
@@ -33,14 +33,7 @@ public class TwitchService : IDisposable, IAppService
     private static int _hypeTrainLevel = 0;
     private bool _disposed = false;
     internal readonly string _oAuthURl = "https://oauth.subathonmanager.app/auth/twitch/login";
-
-    private readonly ILogger? _logger;
-    private readonly IConfig _config;
-
-    private readonly string _tokenFile = Path.GetFullPath(Path.Combine(string.Empty
-        , "data/twitch_token.json"));
-    // internal string TwitchOAuthUrl = "https://id.twitch.tv/oauth2/authorize";
-    // internal int CallbackPort = 14041;  // hardcode cause of app callback url
+    
     internal Uri? EventSubUrl = null;
     
     private DateTime _lastChatDisconnectLog = DateTime.MinValue;
@@ -52,72 +45,49 @@ public class TwitchService : IDisposable, IAppService
     private readonly Utils.ServiceReconnectState _eventSubReconnect =
         new(TimeSpan.FromSeconds(2.5), maxRetries: 200, maxBackoff: TimeSpan.FromMinutes(5));
 
-    private string? AccessToken { get; set; }
     public string? UserName { get; private set; } = string.Empty;
     internal string? Login = string.Empty;
     private string? UserId { get; set; }
 
-    public TwitchService(ILogger<TwitchService>? logger, IConfig config)
-    {
-        // _callbackUrl = $"http://localhost:{CallbackPort}/auth/twitch/callback/";
-        _logger = logger;
-        _config = config;
-    }
-    
+    private string? AccessToken => secureStorage.GetOrDefault(StorageKeys.TwitchAccessToken, string.Empty);
+
     internal Action<string> OpenBrowser = url => Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
-    // private static readonly string[] TwitchScopes =
-    // [
-    //     "user:read:email",
-    //     "bits:read",
-    //     "channel:read:subscriptions",
-    //     "channel:read:redemptions",
-    //     "moderator:read:followers",
-    //     "channel:read:charity",
-    //     "chat:read",
-    //     "chat:edit",
-    //     "channel:read:hype_train"
-    // ];
 
     public bool HasTokenFile()
     {
-        return File.Exists(_tokenFile);
+        return secureStorage.Exists(StorageKeys.TwitchAccessToken) && 
+               !string.IsNullOrWhiteSpace(AccessToken);
     }
 
     public void RevokeTokenFile()
     {
-        if (HasTokenFile()) File.Delete(_tokenFile);
-        AccessToken = string.Empty;
+        secureStorage.Delete(StorageKeys.TwitchAccessToken);
     }
 
     public async Task<bool> ValidateTokenAsync()
     {
         if (!HasTokenFile())
             return false;
-
-        var json = await File.ReadAllTextAsync(_tokenFile);
-        var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-        var token = data?["access_token"];
-
         var api = new TwitchAPI();
         try
         {
-            var validation = await api.Auth.ValidateAccessTokenAsync(token);
+            var validation = await api.Auth.ValidateAccessTokenAsync(AccessToken);
 
             if (validation.ClientId != Config.TwitchClientId)
                 return false;
 
-            _logger?.LogInformation($"Twitch Token Valid for Scopes: {string.Join(',', validation.Scopes)}");
+            logger?.LogInformation($"Twitch Token Valid for Scopes: {string.Join(',', validation.Scopes)}");
             return true;
         }
         catch (HttpRequestException ex)
         {
-            _logger?.LogError(ex, "Could not validate token. Internet connection may be down.");
+            logger?.LogError(ex, "Could not validate token. Internet connection may be down.");
             // return true so we don't delete file
             return true;
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "Twitch Token Validation Error");
+            logger?.LogError(ex, "Twitch Token Validation Error");
             ErrorMessageEvents.RaiseErrorEvent("ERROR", nameof(SubathonEventSource.Twitch),
                 "Twitch Token could not be validated", DateTime.Now.ToLocalTime());
             return false;
@@ -133,11 +103,11 @@ public class TwitchService : IDisposable, IAppService
             if (!tokenValid)
             {
                 RevokeTokenFile();
-                _logger?.LogWarning("Twitch token expired - deleting token file");
+                logger?.LogWarning("Twitch token expired - deleting token file");
             }
             else
             {
-                _logger?.LogInformation("Twitch Service starting up...");
+                logger?.LogInformation("Twitch Service starting up...");
                 await InitializeAsync(ct);
             }
         }
@@ -146,13 +116,6 @@ public class TwitchService : IDisposable, IAppService
     [ExcludeFromCodeCoverage]
     public async Task InitializeAsync(CancellationToken ct = default)
     {
-        if (HasTokenFile())
-        {
-            var json = await File.ReadAllTextAsync(_tokenFile, ct);
-            var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-            AccessToken = data?["access_token"];
-        }
-
         if (string.IsNullOrEmpty(AccessToken))
         {
             await StartOAuthFlowAsync();
@@ -161,15 +124,15 @@ public class TwitchService : IDisposable, IAppService
         try
         {
             await InitializeApiAsync();
-            _logger?.LogDebug("Twitch Initialized API");
+            logger?.LogDebug("Twitch Initialized API");
             await InitializeChatAsync();
-            _logger?.LogDebug("Twitch Initialized Chat");
+            logger?.LogDebug("Twitch Initialized Chat");
             await InitializeEventSubAsync();
-            _logger?.LogDebug("Twitch Initialized EventSub");
+            logger?.LogDebug("Twitch Initialized EventSub");
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "TwitchService Initialization Error");
+            logger?.LogError(ex, "TwitchService Initialization Error");
             ErrorMessageEvents.RaiseErrorEvent("ERROR", nameof(SubathonEventSource.Twitch),
                 $"Error initializing Twitch Service: {ex.Message}. " +
                 $"Please try reconnecting twitch or restarting the application", DateTime.Now);
@@ -179,13 +142,12 @@ public class TwitchService : IDisposable, IAppService
     private async Task StartOAuthFlowAsync()
     {
         Utils.PendingOAuthCallback = null;
-        _logger?.LogDebug("Opening Twitch OAuth...");
+        logger?.LogDebug("Opening Twitch OAuth...");
         OpenBrowser(_oAuthURl);
-        AccessToken = await WaitForProtocolCallbackAsync();   
-        if (!string.IsNullOrEmpty(AccessToken))
+        var token = await WaitForProtocolCallbackAsync();   
+        if (!string.IsNullOrWhiteSpace(token))
         {
-            await File.WriteAllTextAsync(_tokenFile,
-                JsonSerializer.Serialize(new { access_token = AccessToken }));
+            secureStorage.Set(StorageKeys.TwitchAccessToken, token);
         }
     }
     
@@ -197,8 +159,10 @@ public class TwitchService : IDisposable, IAppService
             var cb = Utils.PendingOAuthCallback;
             if (cb?.Provider == "twitch" && !string.IsNullOrEmpty(cb.AccessToken))
             {
+                logger?.LogInformation("Twitch OAuth Callback received");
+                var token = cb.RefreshToken;
                 Utils.PendingOAuthCallback = null;
-                return cb.AccessToken;
+                return token;
             }
             await Task.Delay(250, ct);
         }
@@ -223,7 +187,7 @@ public class TwitchService : IDisposable, IAppService
             UserName = user.DisplayName;
             Login = user.Login;
             UserId = user.Id;
-            _logger?.LogDebug($"Authenticated as {UserName}");
+            logger?.LogDebug($"Authenticated as {UserName}");
             
             IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
             {
@@ -268,11 +232,11 @@ public class TwitchService : IDisposable, IAppService
                     Status = true
                 });
             }); 
-            _logger?.LogDebug("[Twitch] Authenticated Chat as {UserName}", UserName);
+            logger?.LogDebug("[Twitch] Authenticated Chat as {UserName}", UserName);
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, ex.Message);
+            logger?.LogError(ex, ex.Message);
             IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
             {
                 Source = SubathonEventSource.Twitch,
@@ -293,7 +257,7 @@ public class TwitchService : IDisposable, IAppService
     {
         if ((DateTime.Now - _lastChatDisconnectLog).TotalSeconds > 60)
         {
-            _logger?.LogWarning("Twitch Chat Disconnected. Attempting Reconnect...");
+            logger?.LogWarning("Twitch Chat Disconnected. Attempting Reconnect...");
             _lastChatDisconnectLog = DateTime.Now;    
             IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
             {
@@ -328,7 +292,7 @@ public class TwitchService : IDisposable, IAppService
                 _chatReconnect.Retries++;
                 var delay = _chatReconnect.Backoff;
 
-                _logger?.LogDebug(
+                logger?.LogDebug(
                     "[Twitch Chat] Reconnect attempt {Attempt} in {Delay}s",
                     _chatReconnect.Retries,
                     delay.TotalSeconds);
@@ -339,7 +303,7 @@ public class TwitchService : IDisposable, IAppService
 
                     if (_chat.IsConnected)
                     {
-                        _logger?.LogDebug("Twitch Chat reconnect successful.");
+                        logger?.LogDebug("Twitch Chat reconnect successful.");
                         IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
                         {
                             Source = SubathonEventSource.Twitch,
@@ -358,7 +322,7 @@ public class TwitchService : IDisposable, IAppService
                 }
                 catch (Exception ex)
                 {
-                    _logger?.LogWarning(ex, "Twitch Chat reconnect failed");
+                    logger?.LogWarning(ex, "Twitch Chat reconnect failed");
                 }
 
                 _chatReconnect.Backoff = TimeSpan.FromMilliseconds(
@@ -377,7 +341,7 @@ public class TwitchService : IDisposable, IAppService
     [ExcludeFromCodeCoverage]
     private void HandleChatReconnect(object? _, TwitchLib.Communication.Events.OnReconnectedEventArgs args)
     {
-        _logger?.LogInformation("Twitch Chat Reconnected");
+        logger?.LogInformation("Twitch Chat Reconnected");
         _chatReconnect.Cts?.Cancel();
         _chatReconnect.Reset();
         IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
@@ -447,7 +411,7 @@ public class TwitchService : IDisposable, IAppService
     private async Task HandleEventSubConnect(object? s, WebsocketConnectedArgs e)
     {
         bool hasError = false;
-        _logger?.LogInformation("Connected to EventSub WebSocket, session ID: "
+        logger?.LogInformation("Connected to EventSub WebSocket, session ID: "
                                 + _eventSub?.SessionId + ", isReconnect: " + e.IsRequestedReconnect);
         if (!e.IsRequestedReconnect)
         {
@@ -489,7 +453,7 @@ public class TwitchService : IDisposable, IAppService
                 }
                 catch (Exception ex)
                 {
-                    _logger?.LogError(ex, $"Failed to subscribe to {type}: {ex.Message}");
+                    logger?.LogError(ex, $"Failed to subscribe to {type}: {ex.Message}");
                     ErrorMessageEvents.RaiseErrorEvent(
                         "ERROR",
                         nameof(SubathonEventSource.Twitch),
@@ -521,7 +485,7 @@ public class TwitchService : IDisposable, IAppService
     [ExcludeFromCodeCoverage]
     private Task HandleEventSubReconnect(object? s, WebsocketReconnectedArgs e)
     {
-        _logger?.LogInformation("Reconnected EventSub WebSocket.");
+        logger?.LogInformation("Reconnected EventSub WebSocket.");
         if (_eventSubReconnect.Retries >= 1)
             ErrorMessageEvents.RaiseErrorEvent("INFO", nameof(SubathonEventSource.Twitch),
                 "Twitch EventSub has reconnected", DateTime.Now.ToLocalTime());
@@ -545,7 +509,7 @@ public class TwitchService : IDisposable, IAppService
     [ExcludeFromCodeCoverage]
     private Task HandleEventSubDisconnect(object? s, WebsocketDisconnectedArgs e)
     {
-        _logger?.LogWarning("Disconnected EventSub WebSocket.");
+        logger?.LogWarning("Disconnected EventSub WebSocket.");
         
         ErrorMessageEvents.RaiseErrorEvent("WARN", nameof(SubathonEventSource.Twitch),
             "Twitch EventSub has disconnected", DateTime.Now.ToLocalTime());
@@ -588,13 +552,13 @@ public class TwitchService : IDisposable, IAppService
                         "Twitch EventSub reconnect failed after maximum retries.",
                         DateTime.Now.ToLocalTime());
 
-                    _logger?.LogError("EventSub reconnect aborted: max retries reached. Please investigate.");
+                    logger?.LogError("EventSub reconnect aborted: max retries reached. Please investigate.");
                     return;
                 }
 
                 if (!await ValidateTokenAsync())
                 {
-                    _logger?.LogError("EventSub reconnect aborted: Twitch token invalid.");
+                    logger?.LogError("EventSub reconnect aborted: Twitch token invalid.");
                     ErrorMessageEvents.RaiseErrorEvent("ERROR", nameof(SubathonEventSource.Twitch),
                         "Twitch EventSub could not be reconnected - Twitch Token is invalid", DateTime.Now.ToLocalTime());
                     RevokeTokenFile();
@@ -605,7 +569,7 @@ public class TwitchService : IDisposable, IAppService
 
                 var delay = _eventSubReconnect.Backoff;
 
-                _logger?.LogWarning(
+                logger?.LogWarning(
                     "[Twitch EventSub] Reconnect attempt {Attempt} in {Delay}s",
                     _eventSubReconnect.Retries,
                     delay.TotalSeconds);
@@ -625,7 +589,7 @@ public class TwitchService : IDisposable, IAppService
                 }
                 catch (Exception ex)
                 {
-                    _logger?.LogWarning(ex, "EventSub reconnect failed");
+                    logger?.LogWarning(ex, "EventSub reconnect failed");
                 }
 
                 _eventSubReconnect.Backoff = TimeSpan.FromMilliseconds(
@@ -643,7 +607,7 @@ public class TwitchService : IDisposable, IAppService
 
     private Task HandleChannelOnline(object? s, StreamOnlineArgs e)
     {
-        if (_config.GetBool("Twitch", "ResumeOnStart", false))
+        if (config.GetBool("Twitch", "ResumeOnStart", false))
         {
             SubathonEvent subathonEvent = new SubathonEvent
             {
@@ -659,7 +623,7 @@ public class TwitchService : IDisposable, IAppService
             SubathonEvents.RaiseSubathonEventCreated(subathonEvent);
         }
 
-        if (_config.GetBool("Twitch", "UnlockOnStart", false))
+        if (config.GetBool("Twitch", "UnlockOnStart", false))
         {
             SubathonEvent subathonEvent = new SubathonEvent
             {
@@ -680,7 +644,7 @@ public class TwitchService : IDisposable, IAppService
 
     private Task HandleChannelOffline(object? s, StreamOfflineArgs e)
     {
-        if (_config.GetBool("Twitch", "PauseOnEnd", false))
+        if (config.GetBool("Twitch", "PauseOnEnd", false))
         {
             SubathonEvent subathonEvent = new SubathonEvent
             {
@@ -696,7 +660,7 @@ public class TwitchService : IDisposable, IAppService
             SubathonEvents.RaiseSubathonEventCreated(subathonEvent);
         }
 
-        if (_config.GetBool("Twitch", "LockOnEnd", false))
+        if (config.GetBool("Twitch", "LockOnEnd", false))
         {
             SubathonEvent subathonEvent = new SubathonEvent
             {
@@ -821,7 +785,7 @@ public class TwitchService : IDisposable, IAppService
         SubathonEvents.RaiseSubathonEventCreated(subathonEvent);
         if (e.Payload.Event.Type.ToLower() != "cheer")
         {
-            _logger?.LogInformation($"TwitchCheer Event {subathonEvent.Id} " +
+            logger?.LogInformation($"TwitchCheer Event {subathonEvent.Id} " +
                                     $"source was: {e.Payload.Event.Type} {e.Payload.Event.PowerUp?.Type}");
         }
 
@@ -937,6 +901,28 @@ public class TwitchService : IDisposable, IAppService
         OnTeardown();
         _chat?.Disconnect();
         if (_eventSub != null) await _eventSub.DisconnectAsync();
+        
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Source = SubathonEventSource.Twitch,
+            Service = "API",
+            Name = UserName ?? "",
+            Status = false
+        });      
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Source = SubathonEventSource.Twitch,
+            Service = "EventSub",
+            Name = UserName ?? "",
+            Status = false
+        });      
+        IntegrationEvents.RaiseConnectionUpdate(new IntegrationConnection
+        {
+            Source = SubathonEventSource.Twitch,
+            Service = "Chat",
+            Name = UserName ?? "",
+            Status = false
+        });
     }
 
     public static void SimulateRaid(int viewers=50)

--- a/SubathonManager.Tests/DataUnitTests/WidgetEntityHelperTests.cs
+++ b/SubathonManager.Tests/DataUnitTests/WidgetEntityHelperTests.cs
@@ -310,7 +310,7 @@ public class WidgetEntityHelperTests
 
         using var db2 = factory.CreateDbContext();
         var vars = db2.JsVariables.Where(v => v.WidgetId == widget.Id).ToList();
-        Assert.Single(vars);
+        Assert.Equal(vars.Count, WidgetVariableTypeHelper.FontVariables.Length + 1);
         Assert.Equal("myVar", vars[0].Name);
         Assert.Equal("hello", vars[0].Value);
 

--- a/SubathonManager.Tests/IntegrationUnitTests/FourthWallUnitTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/FourthWallUnitTests.cs
@@ -20,6 +20,7 @@ using SubathonManager.Core.Enums;
 using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
 using SubathonManager.Integration;
 using SubathonManager.Tests.Utility;
 using Amounts = Fourthwall.Client.Generated.Models.Openapi.Model.DonationV1.Amounts;
@@ -59,7 +60,13 @@ public class FourthWallServiceTests
         httpFactory.Setup(f => f.CreateClient(nameof(FourthWallService))).Returns(new HttpClient());
 
         IConfig config = MockConfig.MakeMockConfig(configValues);
-        var service = new FourthWallService(logger.Object, config, httpFactory.Object, devTunnels);
+        
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.FourthWallAccessToken] = "123456abcdef",
+            [StorageKeys.FourthWallRefreshToken] = "D34DBEEF",
+        });
+        var service = new FourthWallService(logger.Object, config, httpFactory.Object, devTunnels, storage);
 
         service.OpenBrowser = _ => { };
 
@@ -615,8 +622,12 @@ public class FourthWallServiceTests
         {
             { ("FourthWall", "ForwardUrls"), mockServer.BaseUrl.TrimEnd('/') + "/fw-forward" },
         });
-
-        var service = new FourthWallService(logger.Object, config, httpFactory.Object, devTunnels);
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.FourthWallAccessToken] = "123456abcdef",
+            [StorageKeys.FourthWallRefreshToken] = "D34DBEEF",
+        });
+        var service = new FourthWallService(logger.Object, config, httpFactory.Object, devTunnels, storage);
         service.OpenBrowser = _ => { };
 
         var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { type = "DONATION" }));

--- a/SubathonManager.Tests/IntegrationUnitTests/GoAffProServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/GoAffProServiceTests.cs
@@ -5,6 +5,7 @@ using SubathonManager.Core.Enums;
 using SubathonManager.Core.Events;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
 using SubathonManager.Integration;
 using SubathonManager.Tests.Utility;
 
@@ -63,7 +64,12 @@ public class GoAffProServiceTests
             { ("GoAffPro", $"{store}.CommissionAsDonation"), "true" },
         };
 
-        GoAffProService service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values));
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.GoAffProEmail] = "",
+            [StorageKeys.GoAffProPassword] = "",
+        });
+        GoAffProService service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values), storage);
         
         typeof(SubathonEvents)
             .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
@@ -98,7 +104,12 @@ public class GoAffProServiceTests
             { ("GoAffPro", $"{store}.CommissionAsDonation"), "true" },
         };
 
-        GoAffProService service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values));
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.GoAffProEmail] = "",
+            [StorageKeys.GoAffProPassword] = "",
+        });
+        GoAffProService service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values), storage);
         
         typeof(SubathonEvents)
             .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
@@ -119,11 +130,14 @@ public class GoAffProServiceTests
         {
             { ("GoAffPro", "UwUMarket.Enabled"), "True"},
             { ("GoAffPro", "UwUMarket.Mode"), "Dollar" },
-            { ("GoAffPro", "UwUMarket.CommissionAsDonation"), "true" },
-            { ("GoAffPro", "Email"), email},
-            { ("GoAffPro", "Password"), password},
+            { ("GoAffPro", "UwUMarket.CommissionAsDonation"), "true" }
         };
-        var service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values));
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.GoAffProEmail] = email,
+            [StorageKeys.GoAffProPassword] = password,
+        });
+        var service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values), storage);
         
         typeof(IntegrationEvents)
             .GetField("RaiseConnectionUpdate", BindingFlags.Static | BindingFlags.NonPublic)
@@ -196,10 +210,13 @@ public class GoAffProServiceTests
             { ("GoAffPro", "GamerSupps.Enabled"), "False"},
             { ("GoAffPro", "UwUMarket.Mode"), "Dollar" },
             { ("GoAffPro", "UwUMarket.CommissionAsDonation"), "true" },
-            { ("GoAffPro", "Email"), email},
-            { ("GoAffPro", "Password"), password},
         };
-        var service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values));
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.GoAffProEmail] = email,
+            [StorageKeys.GoAffProPassword] = password,
+        });
+        var service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values), storage);
         service.Endpoint = new Uri(webserver.BaseUrl);
         
         typeof(IntegrationEvents)
@@ -229,11 +246,15 @@ public class GoAffProServiceTests
             { ("GoAffPro", "UwUMarket.Enabled"), "True"},
             { ("GoAffPro", "GamerSupps.Enabled"), "False"},
             { ("GoAffPro", "UwUMarket.Mode"), "Dollar" },
-            { ("GoAffPro", "UwUMarket.CommissionAsDonation"), "true" },
-            { ("GoAffPro", "Email"), "test@example.com"},
-            { ("GoAffPro", "Password"),  "p4$$w0rd"},
+            { ("GoAffPro", "UwUMarket.CommissionAsDonation"), "true" }
         };
-        var service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values));
+        
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.GoAffProEmail] = "test@example.com",
+            [StorageKeys.GoAffProPassword] = "p4$$w0rd",
+        });
+        var service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values), storage);
         service.Endpoint = new Uri(webserver.BaseUrl);
         
         typeof(IntegrationEvents)
@@ -268,10 +289,14 @@ public class GoAffProServiceTests
             { ("GoAffPro", "GamerSupps.Enabled"), "False"},
             { ("GoAffPro", "UwUMarket.Mode"), "Dollar" },
             { ("GoAffPro", "UwUMarket.CommissionAsDonation"), "true" },
-            { ("GoAffPro", "Email"), "test@example.com"},
-            { ("GoAffPro", "Password"),  "p4$$w0rd"},
         };
-        var service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values));
+        
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.GoAffProEmail] = "test@example.com",
+            [StorageKeys.GoAffProPassword] = "p4$$w0rd",
+        });
+        var service = new GoAffProService(logger.Object, MockConfig.MakeMockConfig(values), storage);
         service.MaxRetries = 1;
         service.Endpoint = new Uri(webserver.BaseUrl);
         

--- a/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/KoFiServiceTests.cs
@@ -10,6 +10,7 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
 using SubathonManager.Integration;
 using SubathonManager.Tests.Utility;
 
@@ -48,8 +49,19 @@ public class KoFiServiceTests
         var httpFactory = new Mock<IHttpClientFactory>();
         _ = httpFactory.Setup(f => f.CreateClient(nameof(KoFiService))).Returns(new HttpClient());
 
+        var token = "";
+        if (configValues != null && configValues.ContainsKey(("KoFi", "VerificationToken")))
+        {
+            token = configValues[("KoFi", "VerificationToken")];
+            configValues.Remove(("KoFi", "VerificationToken"));
+        }
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.KoFiVerificationToken] = token
+        });
+        
         IConfig config = MockConfig.MakeMockConfig(configValues);
-        var koFi = new KoFiService(logger.Object, config, httpFactory.Object, devTunnels);
+        var koFi = new KoFiService(logger.Object, config, httpFactory.Object, devTunnels, storage);
         return (koFi, devTunnels);
     }
 
@@ -386,10 +398,15 @@ public class KoFiServiceTests
 
         IConfig config = MockConfig.MakeMockConfig(new Dictionary<(string, string), string>
         {
-            { ("KoFi", "VerificationToken"), token },
             { ("KoFi", "ForwardUrls"), mockServer.BaseUrl.TrimEnd('/') + "/forward" },
         });
-        var service = new KoFiService(logger.Object, config, httpFactory.Object, devTunnels);
+        
+
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.KoFiVerificationToken] =token,
+        });
+        var service = new KoFiService(logger.Object, config, httpFactory.Object, devTunnels, storage);
 
         await service.StartAsync(TestContext.Current.CancellationToken);
 

--- a/SubathonManager.Tests/IntegrationUnitTests/StreamElementsServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/StreamElementsServiceTests.cs
@@ -24,7 +24,7 @@ public class StreamElementsServiceTests
     public async Task InitClient_ShouldReturnFalse_WhenJwtIsEmpty()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
+        
         //config.Setup(c => c.Get("StreamElements", "JWT", "")).Returns("");
         
         var storage = new InMemorySecureStorage(new()
@@ -32,7 +32,7 @@ public class StreamElementsServiceTests
             [StorageKeys.StreamElementsJwt] = "",
         });
 
-        var service = new StreamElementsService(logger.Object, config.Object, storage);
+        var service = new StreamElementsService(logger.Object, storage);
 
         await service.StartAsync(TestContext.Current.CancellationToken);
         
@@ -46,14 +46,14 @@ public class StreamElementsServiceTests
     public void InitClient_ShouldReturnTrue_WhenJwtIsSet()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
+        
         
         var storage = new InMemorySecureStorage(new()
         {
             [StorageKeys.StreamElementsJwt] = "TEST_JWT",
         });
 
-        var service = new StreamElementsService(logger.Object, config.Object, storage);
+        var service = new StreamElementsService(logger.Object, storage);
 
         var result = service.InitClient();
 
@@ -66,13 +66,13 @@ public class StreamElementsServiceTests
     public void SetJwtToken_ShouldUpdateConfigAndSave()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
+        
         var storage = new InMemorySecureStorage(new()
         {
             [StorageKeys.StreamElementsJwt] = "OLD_JWT",
         });
 
-        var service = new StreamElementsService(logger.Object, config.Object, storage);
+        var service = new StreamElementsService(logger.Object, storage);
 
         var result =  service.SetJwtToken("NEW_JWT");
 
@@ -86,14 +86,14 @@ public class StreamElementsServiceTests
     public void SetJwtToken_ShouldNotUpdateConfigAndSave()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
+        
         
         var storage = new InMemorySecureStorage(new()
         {
             [StorageKeys.StreamElementsJwt] = "OLD_JWT",
         });
 
-        var service = new StreamElementsService(logger.Object, config.Object, storage);
+        var service = new StreamElementsService(logger.Object, storage);
 
         var result = service.SetJwtToken("OLD_JWT");
 
@@ -125,8 +125,8 @@ public class StreamElementsServiceTests
     public void OnTip_ShouldRaiseSubathonEvent()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
+        
+        var service = new StreamElementsService(logger.Object, new InMemorySecureStorage());
         
         typeof(SubathonEvents)
             .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
@@ -161,8 +161,8 @@ public class StreamElementsServiceTests
     public void OnConnected_ShouldSetReconnectingFalse_AndLogInformation()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
+        
+        var service = new StreamElementsService(logger.Object, new InMemorySecureStorage());
 
         var method = typeof(StreamElementsService)
             .GetMethod("_OnConnected", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -182,8 +182,8 @@ public class StreamElementsServiceTests
     public async Task OnDisconnected_ShouldSetConnectedFalse_AndRaiseEvent()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
+        
+        var service = new StreamElementsService(logger.Object, new InMemorySecureStorage());
 
         bool eventRaised = false;
         
@@ -221,8 +221,8 @@ public class StreamElementsServiceTests
     public void OnAuthenticated_ShouldSetConnectedTrue_AndRaiseEvent()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
+        
+        var service = new StreamElementsService(logger.Object, new InMemorySecureStorage());
 
         bool eventRaised = false;
         
@@ -269,8 +269,8 @@ public class StreamElementsServiceTests
     public void OnAuthenticateError_ShouldSetConnectedFalse_AndRaiseErrorEvent()
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
-        var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
+        
+        var service = new StreamElementsService(logger.Object, new InMemorySecureStorage());
         
         typeof(IntegrationEvents)
             .GetField("ConnectionUpdated", BindingFlags.Static | BindingFlags.NonPublic)

--- a/SubathonManager.Tests/IntegrationUnitTests/StreamElementsServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/StreamElementsServiceTests.cs
@@ -8,6 +8,7 @@ using StreamElements.WebSocket.Models.Tip;
 using StreamElements.WebSocket.Models.Internal;
 using Microsoft.Extensions.Logging;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
 using SubathonManager.Tests.Utility;
 
 namespace SubathonManager.Tests.IntegrationUnitTests;
@@ -24,9 +25,14 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        config.Setup(c => c.Get("StreamElements", "JWT", "")).Returns("");
+        //config.Setup(c => c.Get("StreamElements", "JWT", "")).Returns("");
+        
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.StreamElementsJwt] = "",
+        });
 
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, storage);
 
         await service.StartAsync(TestContext.Current.CancellationToken);
         
@@ -41,9 +47,13 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        config.Setup(c => c.Get("StreamElements", "JWT", "")).Returns("TEST_JWT");
+        
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.StreamElementsJwt] = "TEST_JWT",
+        });
 
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, storage);
 
         var result = service.InitClient();
 
@@ -57,15 +67,19 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        config.Setup(c => c.Set("StreamElements", "JWT", "NEW_JWT"))
-            .Returns(true);
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.StreamElementsJwt] = "OLD_JWT",
+        });
 
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, storage);
 
-        service.SetJwtToken("NEW_JWT");
+        var result =  service.SetJwtToken("NEW_JWT");
 
-        config.Verify(c => c.Set("StreamElements", "JWT", "NEW_JWT"), Times.Once);
-        config.Verify(c => c.Save(), Times.Once);
+        // config.Verify(c => c.Set("StreamElements", "JWT", "NEW_JWT"), Times.Once);
+        // config.Verify(c => c.Save(), Times.Once);
+        Assert.True(result);
+        Assert.Equal(1, storage.SetSuccessCount);
     }
     
     [Fact]
@@ -73,15 +87,21 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        config.Setup(c => c.Set("StreamElements", "JWT", "OLD_JWT"))
-            .Returns(false);
+        
+        var storage = new InMemorySecureStorage(new()
+        {
+            [StorageKeys.StreamElementsJwt] = "OLD_JWT",
+        });
 
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, storage);
 
-        service.SetJwtToken("OLD_JWT");
+        var result = service.SetJwtToken("OLD_JWT");
 
-        config.Verify(c => c.Set("StreamElements", "JWT", "OLD_JWT"), Times.Once);
-        config.Verify(c => c.Save(), Times.Never);
+        // config.Verify(c => c.Set("StreamElements", "JWT", "OLD_JWT"), Times.Once);
+        // config.Verify(c => c.Save(), Times.Never);
+        Assert.False(result);
+        Assert.Equal(0, storage.SetSuccessCount);
+        Assert.Equal(1, storage.SetCount);
     }
     
     [Fact]
@@ -106,7 +126,7 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
         
         typeof(SubathonEvents)
             .GetField("SubathonEventCreated", BindingFlags.Static | BindingFlags.NonPublic)
@@ -142,7 +162,7 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
 
         var method = typeof(StreamElementsService)
             .GetMethod("_OnConnected", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -163,7 +183,7 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
 
         bool eventRaised = false;
         
@@ -202,7 +222,7 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
 
         bool eventRaised = false;
         
@@ -250,7 +270,7 @@ public class StreamElementsServiceTests
     {
         var logger = new Mock<ILogger<StreamElementsService>>();
         var config = new Mock<Config>();
-        var service = new StreamElementsService(logger.Object, config.Object);
+        var service = new StreamElementsService(logger.Object, config.Object, new InMemorySecureStorage());
         
         typeof(IntegrationEvents)
             .GetField("ConnectionUpdated", BindingFlags.Static | BindingFlags.NonPublic)

--- a/SubathonManager.Tests/IntegrationUnitTests/StreamLabsServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/StreamLabsServiceTests.cs
@@ -8,7 +8,6 @@ using Streamlabs.SocketClient.Messages;
 using System.Reflection;
 using Streamlabs.SocketClient;
 using Streamlabs.SocketClient.Messages.DataTypes;
-using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Objects;
 using SubathonManager.Core.Security;
 using SubathonManager.Tests.Utility;
@@ -32,7 +31,7 @@ namespace SubathonManager.Tests.IntegrationUnitTests
             string token = "valid_token")
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
-            var config = new Mock<IConfig>();
+            
 
             var mockClient = new Mock<IStreamlabsClient>();
             mockClient.Setup(c => c.ConnectAsync()).Returns(Task.CompletedTask);
@@ -43,7 +42,7 @@ namespace SubathonManager.Tests.IntegrationUnitTests
                 [StorageKeys.StreamLabsSocketToken] = token
             });
             
-            var service = new StreamLabsService(logger.Object, config.Object, storage)
+            var service = new StreamLabsService(logger.Object, storage)
             {
                 ClientFactory = _ => mockClient.Object
             };
@@ -55,14 +54,14 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public void IsTokenEmpty_ShouldReturnTrue_WhenTokenNotSet()
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
-            var config = new Mock<IConfig>();
+            
             // config.Setup(c => c.Get("StreamLabs", "SocketToken", "")).Returns("");
             
             var storage = new InMemorySecureStorage(new()
             {
                 [StorageKeys.StreamLabsSocketToken] = "",
             });
-            var service = new StreamLabsService(logger.Object, config.Object, storage);
+            var service = new StreamLabsService(logger.Object, storage);
             Assert.True(service.IsTokenEmpty());
         }
 
@@ -70,13 +69,13 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public void SetSocketToken_ShouldUpdateConfigAndSave()
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
-            var config = new Mock<IConfig>();
+            
             // config.Setup(c => c.Set("StreamLabs", "SocketToken", "NEW_TOKEN")).Returns(true);
             var storage = new InMemorySecureStorage(new()
             {
                 [StorageKeys.StreamLabsSocketToken] = "OLD_TOKEN",
             });
-            var service = new StreamLabsService(logger.Object, config.Object, storage);
+            var service = new StreamLabsService(logger.Object, storage);
 
             var result = service.SetSocketToken("NEW_TOKEN");
 
@@ -91,12 +90,12 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public void SetSocketToken_ShouldNotSave_WhenConfigSetReturnsFalse()
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
-            var config = new Mock<IConfig>();
+            
             var storage = new InMemorySecureStorage(new()
             {
                 [StorageKeys.StreamLabsSocketToken] = "OLD_TOKEN",
             });
-            var service = new StreamLabsService(logger.Object, config.Object, storage);
+            var service = new StreamLabsService(logger.Object, storage);
 
             var result = service.SetSocketToken("OLD_TOKEN");
 
@@ -109,12 +108,12 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public async Task InitClientAsync_ReturnsFalse_WhenTokenEmpty()
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
-            var config = new Mock<IConfig>();
+            
             var storage = new InMemorySecureStorage(new()
             {
                 [StorageKeys.StreamLabsSocketToken] = "",
             });
-            var service = new StreamLabsService(logger.Object, config.Object, storage);
+            var service = new StreamLabsService(logger.Object, storage);
 
             var result = await service.InitClientAsync();
 
@@ -173,12 +172,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public async Task StartAsync_Works()
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
-            var config = new Mock<Config>();
             var storage = new InMemorySecureStorage(new()
             {
                 [StorageKeys.StreamLabsSocketToken] = "",
             });
-            var service = new StreamLabsService(logger.Object, config.Object, storage);
+            var service = new StreamLabsService(logger.Object, storage);
 
 
             await service.StartAsync(TestContext.Current.CancellationToken);
@@ -304,12 +302,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public async Task OnDonation_ShouldRaiseSubathonEvent()
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
-            var config = new Mock<Config>();       
             var storage = new InMemorySecureStorage(new()
             {
                 [StorageKeys.StreamLabsSocketToken] = "",
             });
-            var service = new StreamLabsService(logger.Object, config.Object, storage);
+            var service = new StreamLabsService(logger.Object, storage);
 
 
             var donation = new DonationMessage

--- a/SubathonManager.Tests/IntegrationUnitTests/StreamLabsServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/StreamLabsServiceTests.cs
@@ -10,6 +10,7 @@ using Streamlabs.SocketClient;
 using Streamlabs.SocketClient.Messages.DataTypes;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
 using SubathonManager.Tests.Utility;
 
 namespace SubathonManager.Tests.IntegrationUnitTests
@@ -32,15 +33,20 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
             var config = new Mock<IConfig>();
-            config.Setup(c => c.Get("StreamLabs", "SocketToken", ""))
-                .Returns(token);
 
             var mockClient = new Mock<IStreamlabsClient>();
             mockClient.Setup(c => c.ConnectAsync()).Returns(Task.CompletedTask);
             mockClient.Setup(c => c.DisconnectAsync()).Returns(Task.CompletedTask);
 
-            var service = new StreamLabsService(logger.Object, config.Object);
-            service.ClientFactory = _ => mockClient.Object;
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.StreamLabsSocketToken] = token
+            });
+            
+            var service = new StreamLabsService(logger.Object, config.Object, storage)
+            {
+                ClientFactory = _ => mockClient.Object
+            };
 
             return (service, mockClient);
         }
@@ -50,8 +56,13 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
             var config = new Mock<IConfig>();
-            config.Setup(c => c.Get("StreamLabs", "SocketToken", "")).Returns("");
-            var service = new StreamLabsService(logger.Object, config.Object);
+            // config.Setup(c => c.Get("StreamLabs", "SocketToken", "")).Returns("");
+            
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.StreamLabsSocketToken] = "",
+            });
+            var service = new StreamLabsService(logger.Object, config.Object, storage);
             Assert.True(service.IsTokenEmpty());
         }
 
@@ -60,13 +71,20 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
             var config = new Mock<IConfig>();
-            config.Setup(c => c.Set("StreamLabs", "SocketToken", "NEW_TOKEN")).Returns(true);
-            var service = new StreamLabsService(logger.Object, config.Object);
+            // config.Setup(c => c.Set("StreamLabs", "SocketToken", "NEW_TOKEN")).Returns(true);
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.StreamLabsSocketToken] = "OLD_TOKEN",
+            });
+            var service = new StreamLabsService(logger.Object, config.Object, storage);
 
-            service.SetSocketToken("NEW_TOKEN");
+            var result = service.SetSocketToken("NEW_TOKEN");
 
-            config.Verify(c => c.Set("StreamLabs", "SocketToken", "NEW_TOKEN"), Times.Once);
-            config.Verify(c => c.Save(), Times.Once);
+            // config.Verify(c => c.Set("StreamLabs", "SocketToken", "NEW_TOKEN"), Times.Once);
+            // config.Verify(c => c.Save(), Times.Once);
+            Assert.True(result);
+            Assert.Equal(1, storage.SetSuccessCount);
+            Assert.Equal(1, storage.SetCount);
         }
         
         [Fact]
@@ -74,13 +92,17 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
             var config = new Mock<IConfig>();
-            config.Setup(c => c.Set("StreamLabs", "SocketToken", "OLD_TOKEN")).Returns(false);
-            var service = new StreamLabsService(logger.Object, config.Object);
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.StreamLabsSocketToken] = "OLD_TOKEN",
+            });
+            var service = new StreamLabsService(logger.Object, config.Object, storage);
 
-            service.SetSocketToken("OLD_TOKEN");
+            var result = service.SetSocketToken("OLD_TOKEN");
 
-            config.Verify(c => c.Set("StreamLabs", "SocketToken", "OLD_TOKEN"), Times.Once);
-            config.Verify(c => c.Save(), Times.Never);
+            Assert.False(result);
+            Assert.Equal(0, storage.SetSuccessCount);
+            Assert.Equal(1, storage.SetCount);
         }
 
         [Fact]
@@ -88,8 +110,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
             var config = new Mock<IConfig>();
-            config.Setup(c => c.Get("StreamLabs", "SocketToken", "")).Returns("");
-            var service = new StreamLabsService(logger.Object, config.Object);
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.StreamLabsSocketToken] = "",
+            });
+            var service = new StreamLabsService(logger.Object, config.Object, storage);
 
             var result = await service.InitClientAsync();
 
@@ -149,9 +174,12 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
             var config = new Mock<Config>();
-            config.Setup(c => c.Get("StreamLabs", "SocketToken", "")).Returns("");
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.StreamLabsSocketToken] = "",
+            });
+            var service = new StreamLabsService(logger.Object, config.Object, storage);
 
-            var service = new StreamLabsService(logger.Object, config.Object);
 
             await service.StartAsync(TestContext.Current.CancellationToken);
             Assert.False(service.Connected);
@@ -276,8 +304,13 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public async Task OnDonation_ShouldRaiseSubathonEvent()
         {
             var logger = new Mock<ILogger<StreamLabsService>>();
-            var config = new Mock<Config>();
-            var service = new StreamLabsService(logger.Object, config.Object);
+            var config = new Mock<Config>();       
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.StreamLabsSocketToken] = "",
+            });
+            var service = new StreamLabsService(logger.Object, config.Object, storage);
+
 
             var donation = new DonationMessage
             {

--- a/SubathonManager.Tests/IntegrationUnitTests/TwitchServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/TwitchServiceTests.cs
@@ -1223,7 +1223,6 @@ namespace SubathonManager.Tests.IntegrationUnitTests
                 callbackSim,
                 (Task)oauthMethod.Invoke(service, null)!
             );
-
             Assert.True(service.HasTokenFile());
             Assert.True(storage.Exists(StorageKeys.TwitchAccessToken));
             service.RevokeTokenFile();

--- a/SubathonManager.Tests/IntegrationUnitTests/TwitchServiceTests.cs
+++ b/SubathonManager.Tests/IntegrationUnitTests/TwitchServiceTests.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
 using SubathonManager.Tests.Utility;
 using UserType = TwitchLib.Client.Enums.UserType;
 // ReSharper disable NullableWarningSuppressionIsUsed
@@ -329,8 +330,14 @@ namespace SubathonManager.Tests.IntegrationUnitTests
             {
                 { ("Twitch", "ResumeOnStart"), "true" }
             });
+            
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
 
-            var service = new TwitchService(null, config);
+
+            var service = new TwitchService(null, config, storage);
 
             var ev = CaptureEvent(() =>
                 service
@@ -354,7 +361,13 @@ namespace SubathonManager.Tests.IntegrationUnitTests
                 { ("Twitch", "UnlockOnStart"), "true" }
             });
 
-            var service = new TwitchService(null, config);
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+
+
+            var service = new TwitchService(null, config, storage);
 
             var ev = CaptureEvent(() =>
                 service
@@ -376,9 +389,14 @@ namespace SubathonManager.Tests.IntegrationUnitTests
             var config =MockConfig.MakeMockConfig(new()
             {
                 { ("Twitch", "PauseOnEnd"), "true" }
+            });    
+            
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
             });
 
-            var service = new TwitchService(null, config);
+            var service = new TwitchService(null, config, storage);
 
             var ev = CaptureEvent(() =>
                 service
@@ -401,8 +419,12 @@ namespace SubathonManager.Tests.IntegrationUnitTests
             {
                 { ("Twitch", "LockOnEnd"), "true" }
             });
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
 
-            var service = new TwitchService(null, config);
+            var service = new TwitchService(null, config, storage);
 
             var ev = CaptureEvent(() =>
                 service
@@ -421,7 +443,13 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleChannelFollow_RaisesFollowEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var meta = new WebsocketEventSubMetadata
             {
@@ -477,7 +505,13 @@ namespace SubathonManager.Tests.IntegrationUnitTests
                 { ("Chat", "Commands.Pause.permissions.Whitelist"), "specialguy" }
             });
             CommandService.SetConfig(config);
-            var service = new TwitchService(null, config);
+            
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+
+            var service = new TwitchService(null, config, storage);
             service.Login = "teststreamer";
 
             ChatMessage MakeMessage(string message, bool isVip, bool isMod, bool isBroadcaster, string userName,
@@ -619,61 +653,55 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HasTokenFile_ReturnsCorrectValue()
         {
-            var filePath = Path.GetFullPath(Path.Combine(string.Empty
-                , "data/twitch_token.json"));
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
-            await File.WriteAllTextAsync(filePath, "{}", TestContext.Current.CancellationToken);
+            
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
             Assert.True(service.HasTokenFile());
-            File.Delete(filePath);
+            storage.Delete(StorageKeys.TwitchAccessToken);
             Assert.False(service.HasTokenFile());
             await service.StopAsync(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task RevokeTokenFile_DeletesFileAndClearsAccessToken()
-        {
-            var filePath = Path.GetFullPath(Path.Combine(string.Empty
-                , "data/twitch_token.json"));
-            await File.WriteAllTextAsync(filePath, "{}", TestContext.Current.CancellationToken);
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+        {         
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
             service.RevokeTokenFile();
-            Assert.False(File.Exists(filePath));
-            await service.StopAsync(TestContext.Current.CancellationToken);
-        }
-
-        [Fact]
-        public async Task ValidateTokenAsync_ReturnsFalse_WhenFileMissing()
-        {
-            var filePath = Path.GetFullPath(Path.Combine(string.Empty
-                , "data/twitch_token.json"));
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
-            File.Delete(filePath);
-
-            bool result = await service.ValidateTokenAsync();
-
-            Assert.False(result);
+            Assert.False(storage.Exists(StorageKeys.TwitchAccessToken));
             await service.StopAsync(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task ValidateTokenAsync_ReturnsFalse_WhenTokenInvalid()
-        {
-            var filePath = Path.GetFullPath(Path.Combine(string.Empty
-                , "data/twitch_token.json"));
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
-            await File.WriteAllTextAsync(filePath, JsonSerializer.Serialize(new { access_token = "badtoken" }), TestContext.Current.CancellationToken);
+        {     
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "badtoken",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             bool result = await service.ValidateTokenAsync();
 
             Assert.False(result);
-            File.Delete(filePath);
             await service.StopAsync(TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task HandleSubGift_RaisesGiftSubEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var meta = new WebsocketEventSubMetadata
                 { MessageId = Guid.NewGuid().ToString(), MessageTimestamp = DateTime.UtcNow };
@@ -698,7 +726,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleBitsUse_RaisesCheerEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var meta = new WebsocketEventSubMetadata
                 { MessageId = Guid.NewGuid().ToString(), MessageTimestamp = DateTime.UtcNow };
@@ -723,7 +755,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleChannelSubscribe_RaisesSubEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var args = new ChannelSubscribeArgs
             {
@@ -758,7 +794,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleSubscriptionMsg_RaisesSubEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var args = new ChannelSubscriptionMessageArgs
             {
@@ -790,7 +830,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleChannelRaid_RaisesRaidEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var args = new ChannelRaidArgs
             {
@@ -822,7 +866,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleHypeTrainBeginV2_RaisesStartEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var args = new ChannelHypeTrainBeginV2Args
             {
@@ -855,7 +903,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleHypeTrainProgressV2_RaisesProgressEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
             await service.InvokePrivate("HandleHypeTrainBeginV2", null, new ChannelHypeTrainBeginV2Args
             {
                 Metadata = new WebsocketEventSubMetadata
@@ -904,7 +956,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleHypeTrainEndV2_RaisesEndEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var args = new ChannelHypeTrainEndV2Args
             {
@@ -937,7 +993,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task HandleCharityEvent_RaisesDonationEvent()
         {
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
 
             var args = new ChannelCharityCampaignDonateArgs
             {
@@ -976,7 +1036,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public async Task StopAsync_CanBeCalledTwice_Safely()
         {
             // in case any listeners still exist
-            var service = new TwitchService(null,MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
             await service.StartAsync(CancellationToken.None);
 
             await service.StopAsync(CancellationToken.None);
@@ -987,7 +1051,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public async Task HandleChatMessage_BlerpNotification()
         {
             var config =MockConfig.MakeMockConfig();
-            var service = new TwitchService(null, config);
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null, config, storage);
 
             service.Login = "teststreamer";
 
@@ -1057,7 +1125,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         public async Task HandleChatMessage_BlerpNotificationWrongChat()
         {
             var config =MockConfig.MakeMockConfig();
-            var service = new TwitchService(null, config);
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "123456abcdef",
+            });
+            var service = new TwitchService(null, config, storage);
 
             service.Login = "teststreamer2";
 
@@ -1123,10 +1195,12 @@ namespace SubathonManager.Tests.IntegrationUnitTests
         [Fact]
         public async Task StartOAuthFlow_WritesTokenFile()
         {
-            var tokenFilePath = Path.GetFullPath("data/twitch_token.json");
-            if (File.Exists(tokenFilePath)) File.Delete(tokenFilePath);
 
-            var service = new TwitchService(null, MockConfig.MakeMockConfig());
+            var storage = new InMemorySecureStorage(new()
+            {
+                [StorageKeys.TwitchAccessToken] = "",
+            });
+            var service = new TwitchService(null, MockConfig.MakeMockConfig(), storage);
     
             service.OpenBrowser = _ => { };
 
@@ -1150,12 +1224,10 @@ namespace SubathonManager.Tests.IntegrationUnitTests
                 (Task)oauthMethod.Invoke(service, null)!
             );
 
-            Assert.True(File.Exists(tokenFilePath));
-            var json = await File.ReadAllTextAsync(tokenFilePath, TestContext.Current.CancellationToken);
-            var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-            Assert.Equal(fakeToken, data!["access_token"]);
-
-            File.Delete(tokenFilePath);
+            Assert.True(service.HasTokenFile());
+            Assert.True(storage.Exists(StorageKeys.TwitchAccessToken));
+            service.RevokeTokenFile();
+            Assert.False(service.HasTokenFile());
             await service.StopAsync(TestContext.Current.CancellationToken);
         }
         
@@ -1174,7 +1246,11 @@ namespace SubathonManager.Tests.IntegrationUnitTests
             IntegrationEvents.ConnectionUpdated += Handler;
             try
             {
-                var service = new TwitchService(null,MockConfig.MakeMockConfig());
+                var storage = new InMemorySecureStorage(new()
+                {
+                    [StorageKeys.TwitchAccessToken] = "123456abcdef",
+                });
+                var service = new TwitchService(null,MockConfig.MakeMockConfig(), storage);
                 service.EventSubUrl = wsServer.Uri;
 
                 _ = Task.Run(async () =>

--- a/SubathonManager.Tests/ServicesUnitTests/EventServiceTests.cs
+++ b/SubathonManager.Tests/ServicesUnitTests/EventServiceTests.cs
@@ -494,44 +494,6 @@ public class EventServiceTests
         await service.StopAsync(TestContext.Current.CancellationToken);
         await conn.CloseAsync();
     }
-
-    [Fact]
-    public async Task DeleteSubathonEvent_RemovesPointsAndTime()
-    {
-        var (service, options, conn) = await SetupServiceWithDb(0, false);
-
-        Guid subId;
-        SubathonEvent ev;
-        await using (var db = new AppDbContext(options))
-        {
-            var sub = await db.SubathonDatas.FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
-            subId = sub.Id;
-            Assert.Equal(0, sub.Points);
-            Assert.Equal(0, sub.MillisecondsCumulative);
-            sub.IsLocked = false;
-            sub.Points += 10;
-            sub.MillisecondsCumulative += 120 * 1000;
-            ev = new SubathonEvent
-            {
-                Id = Guid.NewGuid(), SubathonId = sub.Id, EventType = SubathonEventType.ExternalSub,
-                PointsValue = 10, SecondsValue = 120, Source = SubathonEventSource.External, ProcessedToSubathon = true
-            };
-            db.SubathonEvents.Add(ev);
-            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
-        }
-
-        await using var serviceDb = new AppDbContext(options);
-        await service.DeleteSubathonEvent(serviceDb, ev);
-        await Task.Delay(50, TestContext.Current.CancellationToken);
-        await service.StopAsync(TestContext.Current.CancellationToken);
-
-        await using var checkDb = new AppDbContext(options);
-        var subUpdated = await checkDb.SubathonDatas.FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.Equal(0, subUpdated.Points);
-        Assert.Equal(0, subUpdated.MillisecondsCumulative);
-        await conn.CloseAsync();
-    }
-    
     
     [Fact]
     public async Task DeleteOrderTypeSubathonEvent_RemovesPointsAndTimeAndMoney()
@@ -2110,6 +2072,43 @@ public class EventServiceSequentialTests
         await service.StopAsync(TestContext.Current.CancellationToken);
         await conn.CloseAsync();
     }
+    
+    
+    [Fact]
+    public async Task DeleteSubathonEvent_RemovesPointsAndTime()
+    {
+        var (service, options, conn) = await EventServiceTests.SetupServiceWithDb(0, false);
 
+        Guid subId;
+        SubathonEvent ev;
+        await using (var db = new AppDbContext(options))
+        {
+            var sub = await db.SubathonDatas.FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
+            subId = sub.Id;
+            Assert.Equal(0, sub.Points);
+            Assert.Equal(0, sub.MillisecondsCumulative);
+            sub.IsLocked = false;
+            sub.Points += 10;
+            sub.MillisecondsCumulative += 120 * 1000;
+            ev = new SubathonEvent
+            {
+                Id = Guid.NewGuid(), SubathonId = sub.Id, EventType = SubathonEventType.ExternalSub,
+                PointsValue = 10, SecondsValue = 120, Source = SubathonEventSource.External, ProcessedToSubathon = true
+            };
+            db.SubathonEvents.Add(ev);
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await using var serviceDb = new AppDbContext(options);
+        await service.DeleteSubathonEvent(serviceDb, ev);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+        await service.StopAsync(TestContext.Current.CancellationToken);
+
+        await using var checkDb = new AppDbContext(options);
+        var subUpdated = await checkDb.SubathonDatas.FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(0, subUpdated.Points);
+        Assert.Equal(0, subUpdated.MillisecondsCumulative);
+        await conn.CloseAsync();
+    }
 
 }

--- a/SubathonManager.Tests/Utility/InMemorySecureStorage.cs
+++ b/SubathonManager.Tests/Utility/InMemorySecureStorage.cs
@@ -1,0 +1,45 @@
+﻿using SubathonManager.Core.Security.Interfaces;
+
+namespace SubathonManager.Tests.Utility;
+
+public class InMemorySecureStorage(Dictionary<string, string>? seed = null) : ISecureStorage
+{
+    private readonly Dictionary<string, string> _store = seed ?? new Dictionary<string, string>();
+    public int SetCount { get; private set; }
+    public int SetSuccessCount { get; private set; }
+    public int DeleteCount { get; private set; }
+    public int GetCount { get; private set; }
+
+    public bool Set(string key, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return Delete(key);
+
+        var changed = !_store.TryGetValue(key, out var existing) || existing != value;
+        _store[key] = value;
+        SetCount += 1;
+        SetSuccessCount += changed ? 1 : 0;
+        return changed;
+    }
+
+    public string? Get(string key)
+    {
+        GetCount++;
+        return _store.GetValueOrDefault(key);
+    }
+
+    public string? GetOrDefault(string key, string defaultValue = "")
+    {
+        GetCount++;
+        return _store.GetValueOrDefault(key, defaultValue);
+    }
+
+    public bool Delete(string key)
+    {
+        DeleteCount++;
+        return _store.Remove(key);
+    }
+
+    public bool Exists(string key) =>
+        _store.ContainsKey(key);
+}

--- a/SubathonManager.UI/App.Subathon.xaml.cs
+++ b/SubathonManager.UI/App.Subathon.xaml.cs
@@ -11,7 +11,7 @@ namespace SubathonManager.UI;
 
 public partial class App
 {
-    private record SubathonTickState(Guid Id, bool IsPaused, bool IsReversed, double MultiplierValue, DateTime? MultiplierExpiry);
+    private record SubathonTickState(Guid Id, bool IsPaused, bool IsReversed, double MultiplierValue, DateTime? MultiplierExpiry, DateTime? Cap);
     private SubathonTickState? _cachedTickState;
     
     public static async void InitSubathonTimer()
@@ -29,7 +29,8 @@ public partial class App
             data.IsPaused,
             data.IsSubathonReversed(),
             data.Multiplier.Multiplier,
-            data.Multiplier.Duration == null ? null : data.Multiplier.Started + data.Multiplier.Duration
+            data.Multiplier.Duration == null ? null : data.Multiplier.Started + data.Multiplier.Duration,
+            data.CapDateTime
         );
     }
     
@@ -38,39 +39,43 @@ public partial class App
         try
         {
             var state = _cachedTickState;
-            if (state is null or { IsPaused: true, MultiplierValue: 1 }) return;
-
+            if (state is null) return;
+            if (state is { IsPaused: true, MultiplierValue: 1, Cap: null }) return;
+            
             await using var db = await _factory!.CreateDbContextAsync();
 
-            int ran = -1;
-            if (state.IsReversed)
+            if (state is { IsPaused: false })
             {
-                ran = await db.Database.ExecuteSqlRawAsync(
-                    "UPDATE SubathonDatas SET MillisecondsElapsed = MillisecondsElapsed + {0} WHERE IsActive = 1 AND IsPaused = 0 AND MillisecondsElapsed + MillisecondsCumulative > 0",
-                    time.TotalMilliseconds);
-            }
-            else
-            {
-                ran = await db.Database.ExecuteSqlRawAsync(
-                    "UPDATE SubathonDatas SET MillisecondsElapsed = MillisecondsElapsed + {0} WHERE IsActive = 1 AND IsPaused = 0 AND MillisecondsCumulative - MillisecondsElapsed > 0",
-                    time.TotalMilliseconds);
-            }
-        
-            if (ran == 0)
-            {
-                // try to set to equal 0 if it would go negative
+                int ran = -1;
                 if (state.IsReversed)
                 {
-                    await db.Database.ExecuteSqlRawAsync(
-                        "UPDATE SubathonDatas SET MillisecondsElapsed = -MillisecondsCumulative WHERE IsActive = 1 AND IsPaused = 0 AND MillisecondsElapsed + MillisecondsCumulative + 1000 <= 0");
+                    ran = await db.Database.ExecuteSqlRawAsync(
+                        "UPDATE SubathonDatas SET MillisecondsElapsed = MillisecondsElapsed + {0} WHERE IsActive = 1 AND IsPaused = 0 AND MillisecondsElapsed + MillisecondsCumulative > 0",
+                        time.TotalMilliseconds);
                 }
                 else
                 {
-                    await db.Database.ExecuteSqlRawAsync(
-                        "UPDATE SubathonDatas SET MillisecondsElapsed = MillisecondsCumulative WHERE IsActive = 1 AND IsPaused = 0 AND MillisecondsCumulative - MillisecondsElapsed - 1000 <= 0");
+                    ran = await db.Database.ExecuteSqlRawAsync(
+                        "UPDATE SubathonDatas SET MillisecondsElapsed = MillisecondsElapsed + {0} WHERE IsActive = 1 AND IsPaused = 0 AND MillisecondsCumulative - MillisecondsElapsed > 0",
+                        time.TotalMilliseconds);
+                }
+
+                if (ran == 0)
+                {
+                    // try to set to equal 0 if it would go negative
+                    if (state.IsReversed)
+                    {
+                        await db.Database.ExecuteSqlRawAsync(
+                            "UPDATE SubathonDatas SET MillisecondsElapsed = -MillisecondsCumulative WHERE IsActive = 1 AND IsPaused = 0 AND MillisecondsElapsed + MillisecondsCumulative + 1000 <= 0");
+                    }
+                    else
+                    {
+                        await db.Database.ExecuteSqlRawAsync(
+                            "UPDATE SubathonDatas SET MillisecondsElapsed = MillisecondsCumulative WHERE IsActive = 1 AND IsPaused = 0 AND MillisecondsCumulative - MillisecondsElapsed - 1000 <= 0");
+                    }
                 }
             }
-        
+
             if (state.MultiplierExpiry != null && !state.MultiplierValue.Equals(1) && DateTime.Now >= state.MultiplierExpiry)
             {
                 await db.Database.ExecuteSqlRawAsync(
@@ -93,7 +98,16 @@ public partial class App
                     snapshot.Id);
                 snapshot.IsLocked = true;
             }
-        
+            
+            else if (snapshot.CapDateTime != null && DateTime.Now >= snapshot.CapDateTime && snapshot is { IsPaused: false })
+            {
+                await db.Database.ExecuteSqlRawAsync(
+                    "UPDATE SubathonDatas SET IsLocked = 1 WHERE IsActive = 1 AND IsPaused = 1 AND Id = {0}",
+                    snapshot.Id);
+                snapshot.IsLocked = true;
+                snapshot.IsPaused = true;
+            }
+
             SubathonEvents.RaiseSubathonDataUpdate(snapshot, DateTime.Now);
         }
         catch (Exception e)

--- a/SubathonManager.UI/App.xaml.cs
+++ b/SubathonManager.UI/App.xaml.cs
@@ -12,6 +12,8 @@ using SubathonManager.Core.Enums;
 using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Data;
 using SubathonManager.Services;
 using SubathonManager.UI.Services;
@@ -82,6 +84,7 @@ public partial class App
             var config = AppServices.Provider.GetRequiredService<IConfig>();
             config.LoadOrCreateDefault();
             config.MigrateConfig();
+            MigrateSecureStore(config);
 
             bool bitsAsDonationCheck = config.GetBool("Currency", "BitsLikeAsDonation", false);
             Utils.DonationSettings["BitsLikeAsDonation"] = bitsAsDonationCheck;
@@ -158,6 +161,52 @@ public partial class App
             _logger?.LogError(ex, "Error occurred when starting Subathon Manager");
             Current.Shutdown();
         }
+    }
+
+    private void MigrateSecureStore(IConfig config)
+    {
+        bool hasUpdated = false;
+        var secureStorage = AppServices.Provider.GetRequiredService<ISecureStorage>();
+
+        var value = "";
+        value = config.Get("StreamElements", "JWT", string.Empty);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            secureStorage.Set(StorageKeys.StreamElementsJwt, value);
+            hasUpdated |= config.Set("StreamElements", "JWT", string.Empty);
+        }      
+        value = config.Get("StreamLabs", "SocketToken", string.Empty);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            secureStorage.Set(StorageKeys.StreamLabsSocketToken, value);
+            hasUpdated |= config.Set("StreamLabs", "SocketToken", string.Empty);
+        }  
+        value = config.GetFromEncoded("KoFi", "VerificationToken", string.Empty);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            secureStorage.Set(StorageKeys.KoFiVerificationToken, value);
+            hasUpdated |= config.Set("KoFi", "VerificationToken", string.Empty);
+        }
+        value = config.GetFromEncoded("OBS", "Password", string.Empty);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            secureStorage.Set(StorageKeys.OBSWebSocketPassword, value);
+            hasUpdated |= config.Set("OBS", "Password", string.Empty);
+        }
+        value = config.GetFromEncoded("GoAffPro", "Email", string.Empty);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            secureStorage.Set(StorageKeys.GoAffProEmail, value);
+            hasUpdated |= config.Set("GoAffPro", "Email", string.Empty);
+        }
+        value = config.GetFromEncoded("GoAffPro", "Password", string.Empty);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            secureStorage.Set(StorageKeys.GoAffProPassword, value);
+            hasUpdated |= config.Set("GoAffPro", "Password", string.Empty);
+        }
+
+        if (hasUpdated) config.Save();
     }
 
     private static ProtocolMessageType ParseProtocolRequest(StartupEventArgs e)

--- a/SubathonManager.UI/EditRouteWindow.xaml
+++ b/SubathonManager.UI/EditRouteWindow.xaml
@@ -19,6 +19,7 @@
         <conv:CssVariableTypeOptionsConverter x:Key="CssTypeOptionsConverter"/>
         <conv:CssSizeValueConverter x:Key="CssSizeValueConverter"/>
         <conv:CssSizeUnitConverter x:Key="CssSizeUnitConverter"/>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <conv:NullOrEmptyToNullConverter x:Key="NullOrEmptyToNull"/>
         <conv:StringToBoolConverter x:Key="StringToBoolConverter"/>
         <conv:VarTooltipConverter x:Key="VarTooltipConverter"/>
@@ -107,27 +108,42 @@
                     </StackPanel>
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-                    <ui:Button Padding="2"
-                               ToolTip="Copy URL to clipboard"
-                               Width="32" Height="32"
-                               Margin="4,0,4,0"
-                               Click="CopyOverlayUrl_Click"><ui:SymbolIcon Symbol="Link24" />
-                    </ui:Button>
+                <Grid Margin="0,10,0,0">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                        <ui:Button Padding="2"
+                                   ToolTip="Copy URL to clipboard"
+                                   Width="32" Height="32"
+                                   Margin="0,0,4,0"
+                                   Click="CopyOverlayUrl_Click">
+                            <ui:SymbolIcon Symbol="Link24"/>
+                        </ui:Button>
+                        <ui:Button Padding="2" ToolTip="Open in browser"
+                                   Width="32" Height="32"
+                                   Margin="0,0,4,0"
+                                   Click="OpenOverlayInBrowser_Click">
+                            <ui:SymbolIcon Symbol="Open24"/>
+                        </ui:Button>
+                        <ui:Button Padding="2" ToolTip="Export"
+                                   Width="32" Height="32"
+                                   Margin="0,0,4,0"
+                                   Click="ExportRoute_Click">
+                            <ui:SymbolIcon Symbol="ArrowExportUp24"/>
+                        </ui:Button>
+                        <ui:Button Padding="2" ToolTip="Add to OBS as Browser Source"
+                                   Width="32" Height="32"
+                                   Click="AddToObs_Click">
+                            <ui:Button.Visibility>
+                                <Binding Path="ObsConnected"
+                                         RelativeSource="{RelativeSource AncestorType=Window}"
+                                         Converter="{StaticResource BooleanToVisibilityConverter}"/>
+                            </ui:Button.Visibility>
+                            <ui:SymbolIcon Symbol="VideoAdd24"/>
+                        </ui:Button>
+                    </StackPanel>
 
-                    <ui:Button Padding="2" ToolTip="Open in browser"
-                               Width="32" Height="32"
-                               Margin="4,0,4, 0"
-                               Click="OpenOverlayInBrowser_Click"><ui:SymbolIcon Symbol="Open24"/>
-                    </ui:Button>
-
-                    <ui:Button Padding="2" ToolTip="Export"
-                               Width="32" Height="32"
-                               Margin="4,0,154,0"
-                               Click="ExportRoute_Click"><ui:SymbolIcon Symbol="ArrowExportUp24"/>
-                    </ui:Button>
-                    <ui:Button x:Name="SaveRouteButton" Content="Save" Width="80" Click="SaveRouteButton_Click"/>
-                </StackPanel>
+                    <ui:Button x:Name="SaveRouteButton" HorizontalAlignment="Right"
+                               Content="Save" Width="80" Click="SaveRouteButton_Click"/>
+                </Grid>
             </StackPanel>
 
             <StackPanel Grid.Row="1">

--- a/SubathonManager.UI/EditRouteWindow.xaml.cs
+++ b/SubathonManager.UI/EditRouteWindow.xaml.cs
@@ -399,7 +399,21 @@ public partial class EditRouteWindow
 
         (List<JsVariable> jsVars, _, _) =
             helper.LoadNewJsVariables(newWidget, metadata);
-
+        
+        var allVarTypes = jsVars.Select(j => j.Type).Distinct().ToList();
+        var missingFontTypes = WidgetVariableTypeHelper.FontVariables.ToList().Where(x => !allVarTypes.Contains(x)).ToList();
+        foreach (var fontVar in missingFontTypes)
+        {
+            jsVars.Add(new JsVariable
+            {
+                WidgetId = newWidget.Id,
+                Type = fontVar,
+                Name = $"{fontVar}s",
+                Description = $"Custom font names to include from {fontVar}s, comma separated",
+                Value = string.Empty
+            });
+        }
+        
         if (jsVars.Count > 0)
         {
             newWidget.JsVariables = jsVars;

--- a/SubathonManager.UI/EditRouteWindow.xaml.cs
+++ b/SubathonManager.UI/EditRouteWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Windows;
 using System.Text.RegularExpressions;
@@ -11,12 +12,15 @@ using SubathonManager.Core.Models;
 using SubathonManager.Core;
 using SubathonManager.Core.Enums;
 using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Objects;
 using SubathonManager.Data;
+using SubathonManager.UI.Services;
+using SubathonManager.UI.Views;
 using Wpf.Ui.Controls;
 
 namespace SubathonManager.UI;
 
-public partial class EditRouteWindow
+public partial class EditRouteWindow : INotifyPropertyChanged
 {
     public readonly Guid EditorRouteId;
     private Route? _route;
@@ -28,6 +32,16 @@ public partial class EditRouteWindow
     private string _lastFolder = string.Empty;
     private bool _loadedWebView = false;
     private int _suppressCount = 0;
+    private bool _obsConnected;
+    public bool ObsConnected
+    {
+        get => _obsConnected;
+        set { _obsConnected = value; OnPropertyChanged(); }
+    }
+    
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     
     [GeneratedRegex(@"^-?[\d.]+")]
     private static partial Regex IsNumberRegex();
@@ -40,6 +54,9 @@ public partial class EditRouteWindow
         EditorRouteId = routeId;
         WidgetsList.ItemsSource = _widgets;
         Loaded += EditRouteWindow_Loaded;
+        ObsConnected = ServiceManager.OBS.Connected;
+        IntegrationEvents.ConnectionUpdated += OnObsConnectionUpdated;
+        Closed += (_, _) => IntegrationEvents.ConnectionUpdated -= OnObsConnectionUpdated;
     }
     private async void EditRouteWindow_Loaded(object sender, RoutedEventArgs e)
     {
@@ -476,6 +493,35 @@ public partial class EditRouteWindow
         {
             UiUtils.UiUtils.UpdateButtonPendingBorder(border, hasPendingChanges);
         });
+    }
+    
+    private void OnObsConnectionUpdated(IntegrationConnection? connection)
+    {
+        if (connection is not { Source: SubathonEventSource.OBS }) return;
+        Dispatcher.Invoke(() => ObsConnected = connection.Status);
+    }
+
+    private void AddToObs_Click(object sender, RoutedEventArgs e)
+    {
+        if (_route == null) return;
+        try
+        {
+            var scenes = ServiceManager.OBS.GetScenes();
+            string currentScene = ServiceManager.OBS.GetCurrentScene();
+            var config = AppServices.Provider.GetRequiredService<IConfig>();
+            string url = _route.GetRouteUrl(config);
+
+            var dialog = new ObsAddSourceDialog(_route, url, scenes, currentScene)
+            {
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+            dialog.ShowDialog();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "[OBS] Failed to open add source dialog for overlay {Name}", _route.Name);
+        }
     }
 
 }

--- a/SubathonManager.UI/MainWindow.Cap.cs
+++ b/SubathonManager.UI/MainWindow.Cap.cs
@@ -1,0 +1,135 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using Microsoft.EntityFrameworkCore;
+using SubathonManager.Core.Events;
+
+namespace SubathonManager.UI;
+
+public partial class MainWindow
+{
+    private void CapBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (CapPopup.IsOpen)
+        {
+            CapPopup.IsOpen = false;
+            return;
+        }
+
+        using var db = _factory.CreateDbContext();
+        var subathon = db.SubathonDatas.AsNoTracking().FirstOrDefault(s => s.IsActive);
+        if (subathon == null) return;
+
+        if (subathon.CapDateTime.HasValue)
+        {
+            var cap = subathon.CapDateTime.Value;
+            CapDatePicker.SelectedDate = cap.Date;
+            CapHourInput.Text = cap.Hour.ToString("D2");
+            CapMinuteInput.Text = cap.Minute.ToString("D2");
+            CapCurrentLabel.Text = $"Cap: {cap:MMM d, h:mm tt}";
+            CapIcon.Symbol = Wpf.Ui.Controls.SymbolRegular.Flag24;
+        }
+        else
+        {
+            CapDatePicker.SelectedDate = DateTime.Today;
+            CapHourInput.Text = DateTime.Now.AddHours(1).Hour.ToString("D2");
+            CapMinuteInput.Text = "00";
+            CapCurrentLabel.Text = "No cap set";
+        }
+
+        CapValidationMsg.Text = "";
+        CapPopup.IsOpen = true;
+    }
+
+    private void CapDatePicker_SelectedDateChanged(object sender, SelectionChangedEventArgs e)
+    {
+        ValidateCapInput();
+    }
+
+    private void CapTime_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        ValidateCapInput();
+    }
+
+    private bool ValidateCapInput()
+    {
+        if (CapDatePicker.SelectedDate == null)
+        {
+            CapValidationMsg.Text = "Please select a date.";
+            SetCapBtn.IsEnabled = false;
+            return false;
+        }
+
+        if (!int.TryParse(CapHourInput.Text, out int hour) || hour < 0 || hour > 23)
+        {
+            CapValidationMsg.Text = "Hour must be 0–23.";
+            SetCapBtn.IsEnabled = false;
+            return false;
+        }
+
+        if (!int.TryParse(CapMinuteInput.Text, out int minute) || minute < 0 || minute > 59)
+        {
+            CapValidationMsg.Text = "Minute must be 0–59.";
+            SetCapBtn.IsEnabled = false;
+            return false;
+        }
+
+        var picked = CapDatePicker.SelectedDate.Value.Date
+            .AddHours(hour)
+            .AddMinutes(minute);
+
+        if (picked <= DateTime.Now)
+        {
+            CapValidationMsg.Text = "Cap must be in the future.";
+            SetCapBtn.IsEnabled = false;
+            return false;
+        }
+
+        CapValidationMsg.Text = "";
+        SetCapBtn.IsEnabled = true;
+        return true;
+    }
+
+    private void SetCap_Click(object sender, RoutedEventArgs e)
+    {
+        if (!ValidateCapInput()) return;
+
+        int hour = int.Parse(CapHourInput.Text);
+        int minute = int.Parse(CapMinuteInput.Text);
+        var capDateTime = CapDatePicker.SelectedDate!.Value.Date
+            .AddHours(hour)
+            .AddMinutes(minute);
+
+        using var db = _factory.CreateDbContext();
+        var subathon = db.SubathonDatas.FirstOrDefault(s => s.IsActive);
+        if (subathon == null) return;
+
+        subathon.CapDateTime = capDateTime;
+        db.SaveChanges();
+
+        CapCurrentLabel.Text = $"Cap: {capDateTime:MMM d, h:mm tt}";
+        CapIcon.Symbol = Wpf.Ui.Controls.SymbolRegular.Flag24;
+        CapPopup.IsOpen = false;
+        
+        var snapshot = db.SubathonDatas
+            .Where(x => x.Id == subathon.Id && x.IsActive)
+            .Include(x => x.Multiplier)
+            .AsNoTracking()
+            .FirstOrDefault();
+        if (snapshot != null)
+            SubathonEvents.RaiseSubathonDataUpdate(snapshot, DateTime.Now);
+    }
+
+    private void ClearCap_Click(object sender, RoutedEventArgs e)
+    {
+        using var db = _factory.CreateDbContext();
+        var subathon = db.SubathonDatas.FirstOrDefault(s => s.IsActive);
+        if (subathon == null) return;
+
+        subathon.CapDateTime = null;
+        db.SaveChanges();
+
+        CapCurrentLabel.Text = "No cap set";
+        CapIcon.Symbol = Wpf.Ui.Controls.SymbolRegular.FlagOff24;
+        CapPopup.IsOpen = false;
+    }
+}

--- a/SubathonManager.UI/MainWindow.Obs.cs
+++ b/SubathonManager.UI/MainWindow.Obs.cs
@@ -1,0 +1,65 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Models;
+using SubathonManager.Core.Objects;
+using SubathonManager.UI.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SubathonManager.Core;
+using SubathonManager.Core.Interfaces;
+using SubathonManager.UI.Views;
+
+namespace SubathonManager.UI;
+
+public partial class MainWindow : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    private bool _obsConnected;
+    public bool ObsConnected
+    {
+        get => _obsConnected;
+        set { _obsConnected = value; OnPropertyChanged(); }
+    }
+
+    private void InitObsIntegration()
+    {
+        IntegrationEvents.ConnectionUpdated += OnObsConnectionUpdated;
+        ObsConnected = ServiceManager.OBS.Connected;
+    }
+
+    private void OnObsConnectionUpdated(IntegrationConnection? connection)
+    {
+        if (connection is not { Source: SubathonEventSource.OBS }) return;
+        Dispatcher.Invoke(() => ObsConnected = connection.Status);
+    }
+
+    private void AddToObs_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Wpf.Ui.Controls.Button { DataContext: Route route }) return;
+
+        try
+        {
+            var scenes = ServiceManager.OBS.GetScenes(); // returns List<string>
+            string currentScene = ServiceManager.OBS.GetCurrentScene();
+            var config = AppServices.Provider.GetRequiredService<IConfig>();
+            string url = route.GetRouteUrl(config);
+
+            var dialog = new ObsAddSourceDialog(route, url, scenes, currentScene)
+            {
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner
+            };
+            dialog.ShowDialog();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "[OBS] Failed to open add source dialog for route {Name}", route.Name);
+        }
+    }
+}

--- a/SubathonManager.UI/MainWindow.Stats.cs
+++ b/SubathonManager.UI/MainWindow.Stats.cs
@@ -1,0 +1,64 @@
+﻿using System.Windows;
+using System.Windows.Input;
+using Microsoft.EntityFrameworkCore;
+using SubathonManager.Core.Enums;
+
+namespace SubathonManager.UI;
+
+public partial class MainWindow
+{
+    private void TimerHoverArea_MouseEnter(object sender, MouseEventArgs e)
+    {
+        RefreshStatsPanel();
+        StatsPopup.IsOpen = true;
+    }
+
+    private void TimerHoverArea_MouseLeave(object sender, MouseEventArgs e)
+    {
+        StatsPopup.IsOpen = false;
+    }
+
+    private void RefreshStatsPanel()
+    {
+        Dispatcher.Invoke(() =>
+        {     
+            using var db = _factory.CreateDbContext();
+            var subathon = db.SubathonDatas
+                .AsNoTracking()
+                .FirstOrDefault(s => s.IsActive);
+
+            if (subathon == null) return;
+            TimeSpan elapsed = TimeSpan.FromMilliseconds(subathon.MillisecondsElapsed);
+
+            TimeSpan totalAccumulated = TimeSpan.FromMilliseconds(subathon.MillisecondsCumulative);
+            
+            ////////////////////////
+            StatsElapsedTime.Text = FormatTimeSpan(elapsed);
+            if (subathon.IsSubathonReversed())
+            {
+                StatsTotalAccumulated.Visibility = Visibility.Collapsed;
+                StatsAccu.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                StatsTotalAccumulated.Visibility = Visibility.Visible;
+                StatsAccu.Visibility = Visibility.Visible;
+                StatsTotalAccumulated.Text = FormatTimeSpan(totalAccumulated);
+            }
+
+            int eventCount = db.SubathonEvents.Count(ev => ev.SubathonId == subathon.Id &&
+                                                           ev.Command == SubathonCommandType.None && 
+                                                           ev.Source != SubathonEventSource.Simulated);
+            StatsTotalEvents.Text = $"{eventCount:N0}";
+        });
+    }
+
+    private static string FormatTimeSpan(TimeSpan ts)
+    {
+        if (ts.TotalDays >= 1)
+            return $"{(int)ts.TotalDays}d {ts.Hours}h {ts.Minutes}m";
+        if (ts.TotalHours >= 1)
+            return $"{(int)ts.TotalHours}h {ts.Minutes}m {ts.Seconds}s";
+        return $"{ts.Minutes}m {ts.Seconds}s";
+    }
+}

--- a/SubathonManager.UI/MainWindow.SubathonTimer.cs
+++ b/SubathonManager.UI/MainWindow.SubathonTimer.cs
@@ -50,6 +50,18 @@ namespace SubathonManager.UI
                     var lockTt = subathon.IsLocked ? "Unlock" : "Lock";
                     if (!lockTt.Equals(ToggleLockTimerBtn.ToolTip))
                         ToggleLockTimerBtn.ToolTip = lockTt;
+                    
+                    var capSymbol = subathon.CapDateTime.HasValue && subathon.CapDateTime > DateTime.Now
+                        ? SymbolRegular.Flag24
+                        : SymbolRegular.FlagOff24;
+                    if (CapIcon.Symbol != capSymbol)
+                        CapIcon.Symbol = capSymbol;
+
+                    var capColor = subathon.IsCapInEffect()
+                        ? System.Windows.Media.Brushes.Orange
+                        : (System.Windows.Media.Brush)FindResource("TextFillColorPrimaryBrush");
+                    if (CapIcon.Foreground != capColor)
+                        CapIcon.Foreground = capColor;
                 });
             }
         }

--- a/SubathonManager.UI/MainWindow.xaml
+++ b/SubathonManager.UI/MainWindow.xaml
@@ -13,6 +13,7 @@
                        MinHeight="800" MinWidth="1200"
                        MaxHeight="800" MaxWidth="1200">
     <ui:FluentWindow.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <Style x:Key="NoHoverOverlayButton" TargetType="ui:Button" BasedOn="{StaticResource {x:Type ui:Button}}">
             <Setter Property="Background" Value="{DynamicResource SolidOverlayButtonColor}"/>
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}"/>
@@ -130,13 +131,97 @@
                                <RowDefinition Height="*"/>
                            </Grid.RowDefinitions>
                            <StackPanel Grid.Row="0" Margin="10 2 10 10">
-                               <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,16,5">
-                                   <ui:Button x:Name="StartSubathonBtn" 
-                                                      Click="StartNewSubathon_Click"
-                                                      Content="Start New Subathon"
-                                                      Width="220" Height="30" Margin="0,2,0,5"/>
-                               </StackPanel>
-                               
+                           <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,16,5">
+                                <Grid>
+                                    <ui:Button x:Name="CapBtn"
+                                               Click="CapBtn_Click"
+                                               ToolTip="Set End Date (Cap)"
+                                               Width="30" Height="30" Margin="0,2,8,5"
+                                               Padding="2">
+                                        <ui:SymbolIcon x:Name="CapIcon" Symbol="Flag24" Width="20" Height="20"/>
+                                    </ui:Button>
+
+                                    <Popup x:Name="CapPopup"
+                                           PlacementTarget="{Binding ElementName=CapBtn}"
+                                           Placement="Bottom"
+                                           StaysOpen="False"
+                                           AllowsTransparency="True"
+                                           PopupAnimation="Fade">
+                                        <Border Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="8"
+                                                Padding="14">
+                                            <StackPanel Width="240">
+                                                <TextBlock Text="Set end date / cap" FontSize="14" FontWeight="SemiBold" Margin="0 0 0 10"/>
+
+                                                <TextBlock x:Name="CapCurrentLabel"
+                                                           Text="No cap set"
+                                                           FontSize="12"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                           Margin="0 0 0 10"/>
+
+                                                <TextBlock Text="Date" FontSize="11" Margin="0 0 0 3"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                <DatePicker x:Name="CapDatePicker"
+                                                            Height="34"
+                                                            Opacity="1"
+                                                            Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                            Margin="0 0 0 8"
+                                                            SelectedDateChanged="CapDatePicker_SelectedDateChanged">
+                                                </DatePicker>
+
+                                                <TextBlock Text="Time (24h)" FontSize="11" Margin="0 0 0 3"
+                                                           Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                                                <StackPanel Orientation="Horizontal" Margin="0 0 0 4">
+                                                    <ui:TextBox x:Name="CapHourInput"
+                                                                Width="72" Height="34"
+                                                                PlaceholderText="HH"
+                                                                ClearButtonEnabled="False"
+                                                                MaxLength="2"
+                                                                PreviewTextInput="NumberOnly_PreviewTextInput"
+                                                                TextChanged="CapTime_TextChanged"
+                                                                Margin="0 0 6 0"/>
+                                                    <TextBlock Text=":" VerticalAlignment="Center" FontSize="18" Margin="0 0 6 0"/>
+                                                    <ui:TextBox x:Name="CapMinuteInput"
+                                                                Width="72" Height="34"
+                                                                PlaceholderText="MM"
+                                                                MaxLength="2"
+                                                                ClearButtonEnabled="False"
+                                                                PreviewTextInput="NumberOnly_PreviewTextInput"
+                                                                TextChanged="CapTime_TextChanged"/>
+                                                </StackPanel>
+
+                                                <TextBlock x:Name="CapValidationMsg"
+                                                           Text=""
+                                                           FontSize="11"
+                                                           Foreground="OrangeRed"
+                                                           Margin="0 2 0 8"
+                                                           TextWrapping="Wrap"/>
+
+                                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                                    <ui:Button x:Name="ClearCapBtn"
+                                                               Content="Clear"
+                                                               Appearance="Secondary"
+                                                               Width="72" Height="30"
+                                                               Margin="0 0 8 0"
+                                                               Click="ClearCap_Click"/>
+                                                    <ui:Button x:Name="SetCapBtn"
+                                                               Content="Set Cap"
+                                                               Width="80" Height="30"
+                                                               Click="SetCap_Click"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </Border>
+                                    </Popup>
+                                </Grid>
+
+                                <ui:Button x:Name="StartSubathonBtn"
+                                           Click="StartNewSubathon_Click"
+                                           Content="Start New Subathon"
+                                           Width="220" Height="30" Margin="0,2,0,5"/>
+                            </StackPanel>
+                           
                                <Grid Margin="124 0 0 0 ">
                                    
                                    <Grid.ColumnDefinitions>
@@ -150,7 +235,6 @@
                                                   Width="50" Height="50" Margin="0,10,6,5">
                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                                <ui:SymbolIcon x:Name="PauseIcon" Symbol="Pause28" Width="54" Height="44" Margin="0"/>
-                                               <!-- <TextBlock x:Name="PauseText" Text="Pause Timer" VerticalAlignment="Center"/> -->
                                            </StackPanel>
                                        </ui:Button>
                                        <ui:Button x:Name="ToggleLockTimerBtn"
@@ -159,17 +243,60 @@
                                                   Width="50" Height="50" Margin="0,10,6,5">
                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                                <ui:SymbolIcon x:Name="LockIcon" Symbol="LockClosed28" Width="54" Height="44" Margin="0"/>
-                                               <!-- <TextBlock x:Name="LockText" Text="Lock Subathon" VerticalAlignment="Center"/> -->
                                            </StackPanel>
                                        </ui:Button>
                                    </StackPanel>
                                    <StackPanel Grid.Column="1" HorizontalAlignment="Right"> 
                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                           <ui:SymbolIcon x:Name="LockStatus" Symbol="LockClosed32"
-                                                          Width="50" Height="50" Margin="4"/>
-                                           <TextBlock x:Name="TimerValue" HorizontalAlignment="Right" 
-                                                      Text="" VerticalAlignment="Center" FontSize="44" Margin="0 6 16 4"/>
-                                           <!-- <TextBlock x:Name="LockText" Text="Lock Subathon" VerticalAlignment="Center"/> -->
+                                           <Grid>
+                                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                                    <ui:SymbolIcon x:Name="LockStatus" Symbol="LockClosed32"
+                                                                   Width="50" Height="50" Margin="4"/>
+                                                    <Grid x:Name="TimerHoverArea"
+                                                          MouseEnter="TimerHoverArea_MouseEnter"
+                                                          MouseLeave="TimerHoverArea_MouseLeave">
+                                                        <TextBlock x:Name="TimerValue" HorizontalAlignment="Right" 
+                                                                   Text="" VerticalAlignment="Center" FontSize="44" Margin="0 6 16 4"/>
+                                                        <Popup x:Name="StatsPopup"
+                                                               PlacementTarget="{Binding ElementName=TimerHoverArea}"
+                                                               Placement="Bottom"
+                                                               StaysOpen="True"
+                                                               AllowsTransparency="True"
+                                                               PopupAnimation="Fade">
+                                                            <Border Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                                    BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                                                                    BorderThickness="1"
+                                                                    CornerRadius="8"
+                                                                    Padding="16">
+                                                                <StackPanel Width="240">
+                                                                    <TextBlock Text="Subathon Stats" FontSize="14" FontWeight="SemiBold" Margin="0 0 0 10"/>
+                                                                    <Grid>
+                                                                        <Grid.ColumnDefinitions>
+                                                                            <ColumnDefinition Width="*"/>
+                                                                            <ColumnDefinition Width="Auto"/>
+                                                                        </Grid.ColumnDefinitions>
+                                                                        <Grid.RowDefinitions>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                            <RowDefinition Height="Auto"/>
+                                                                        </Grid.RowDefinitions>
+
+                                                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Elapsed Time" VerticalAlignment="Center" Margin="0 5"/>
+                                                                        <TextBlock Grid.Row="0" Grid.Column="1" x:Name="StatsElapsedTime" Text="—" FontWeight="SemiBold" HorizontalAlignment="Right" Margin="0 5"/>
+
+                                                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Total Accumulated" VerticalAlignment="Center" Margin="0 5" x:Name="StatsAccu"/>
+                                                                        <TextBlock Grid.Row="1" Grid.Column="1" x:Name="StatsTotalAccumulated" Text="—" FontWeight="SemiBold" HorizontalAlignment="Right" Margin="0 5"/>
+
+                                                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Total Events" VerticalAlignment="Center" Margin="0 5"/>
+                                                                        <TextBlock Grid.Row="2" Grid.Column="1" x:Name="StatsTotalEvents" Text="—" FontWeight="SemiBold" HorizontalAlignment="Right" Margin="0 5"/>
+                                                                    </Grid>
+                                                                </StackPanel>
+                                                            </Border>
+                                                        </Popup>
+                                                    </Grid>
+                                                </StackPanel>
+                                            </Grid>
                                        </StackPanel>
                                    </StackPanel>
                                 </Grid>
@@ -178,13 +305,13 @@
                                        <ColumnDefinition Width="120"/>
                                        <ColumnDefinition Width="*"/>
                                    </Grid.ColumnDefinitions>
-                                   <StackPanel Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left">
-                                       <ui:Button Click="SendRefreshRequest_Click" Width="50" Height="50" Margin="12 2 6 2" ToolTip="Refresh Overlays">
-                                           <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                               <ui:SymbolIcon Symbol="Recycle32" Width="54" VerticalAlignment="Center" Height="44" Margin="2 0"/>
-                                           </StackPanel>
-                                       </ui:Button>
-                                   </StackPanel>
+                                    <StackPanel Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left">
+                                        <ui:Button Click="SendRefreshRequest_Click" Width="50" Height="50" Margin="12 2 6 2" ToolTip="Refresh Overlays">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="Recycle32" Width="54" VerticalAlignment="Center" Height="44" Margin="2 0"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                    </StackPanel>
                                    <StackPanel Grid.Column="1" Orientation="Horizontal"  HorizontalAlignment="Right" Margin="0,0,16,5">
                                        <ui:Button x:Name="AddTimeBtn"
                                                   Click="AddTime_Click"
@@ -390,6 +517,20 @@
                                                         Margin="10,0,0,0">
                                                 <ui:Button ToolTip="Copy Link" Click="CopyRouteUrl_Click" Padding="2" Style="{StaticResource OpaqueSecondaryButton}" Width="32" Height="32" Margin="4,0" Foreground="{DynamicResource TextFillColorPrimaryBrush}">
                                                     <ui:SymbolIcon Symbol="Link24" />
+                                                </ui:Button>
+                                                <ui:Button ToolTip="Add to OBS as Browser Source"
+                                                           Click="AddToObs_Click"
+                                                           Padding="2"
+                                                           Tag="ObsBtn"
+                                                           Style="{StaticResource OpaqueSecondaryButton}"
+                                                           Width="32" Height="32" Margin="4,0"
+                                                           Foreground="{DynamicResource TextFillColorPrimaryBrush}">
+                                                    <ui:Button.Visibility>
+                                                        <Binding Path="ObsConnected"
+                                                                 RelativeSource="{RelativeSource AncestorType=Window}"
+                                                                 Converter="{StaticResource BooleanToVisibilityConverter}"/>
+                                                    </ui:Button.Visibility>
+                                                    <ui:SymbolIcon Symbol="VideoAdd24"/>
                                                 </ui:Button>
                                                 <ui:Button ToolTip="Edit" Click="EditRoute_Click" Padding="2" Style="{StaticResource OpaqueSecondaryButton}" Width="32" Height="32" Margin="4,0" Foreground="{DynamicResource TextFillColorPrimaryBrush}">
                                                     <ui:SymbolIcon Symbol="Edit24" />

--- a/SubathonManager.UI/MainWindow.xaml.cs
+++ b/SubathonManager.UI/MainWindow.xaml.cs
@@ -41,6 +41,7 @@ namespace SubathonManager.UI
             SubathonEvents.SubathonDataUpdate += UpdateTimerValue;
             SubathonEvents.SubathonDataUpdate += UpdateMultiplierUi;
             Task.Run(App.InitSubathonTimer);
+            InitObsIntegration();
         }
 
         protected override void OnSourceInitialized(EventArgs e)

--- a/SubathonManager.UI/Services/ServiceManager.cs
+++ b/SubathonManager.UI/Services/ServiceManager.cs
@@ -34,6 +34,7 @@ public class ServiceManager(ILogger<ServiceManager> logger)
 
     public async Task StartIntegrationsAsync()
     {
+        await StartAsync<OBSService>();
         await StartAsync<TwitchService>();
         await StartAsync<YouTubeService>();
         await StartAsync<PicartoService>();
@@ -48,6 +49,7 @@ public class ServiceManager(ILogger<ServiceManager> logger)
 
     public async Task StopIntegrationsAsync()
     {
+        await StopAsync<OBSService>();
         await StopAsync<TwitchService>();
         await StopAsync<YouTubeService>();
         await StopAsync<PicartoService>();
@@ -141,6 +143,7 @@ public class ServiceManager(ILogger<ServiceManager> logger)
     public static PicartoService Picarto => Provider.GetRequiredService<PicartoService>();
     public static StreamElementsService StreamElements => Provider.GetRequiredService<StreamElementsService>();
     public static StreamLabsService StreamLabs => Provider.GetRequiredService<StreamLabsService>();
+    public static OBSService OBS => Provider.GetRequiredService<OBSService>();
     
     public static WebServer Server => Provider.GetRequiredService<WebServer>();
     public static TimerService Timer => Provider.GetRequiredService<TimerService>();

--- a/SubathonManager.UI/Services/ServiceRegistration.cs
+++ b/SubathonManager.UI/Services/ServiceRegistration.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SubathonManager.Core;
 using SubathonManager.Core.Interfaces;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Data;
 using SubathonManager.Integration;
 using SubathonManager.Server;
@@ -32,7 +34,7 @@ public static class ServiceRegistration
         services.AddSingleton<EventService>();
         services.AddSingleton<WebServer>();
         services.AddSingleton<TelemetryService>();
-
+        services.AddSingleton<ISecureStorage, DpapiSecureStorage>();
     }
     
     public static void AddIntegrations(this IServiceCollection services)

--- a/SubathonManager.UI/Services/ServiceRegistration.cs
+++ b/SubathonManager.UI/Services/ServiceRegistration.cs
@@ -75,6 +75,7 @@ public static class ServiceRegistration
         // Other //
         services.AddHttpClient(nameof(DiscordWebhookService)).SetHandlerLifetime(Timeout.InfiniteTimeSpan);;
         services.AddSingleton<DiscordWebhookService>();
+        services.AddSingleton<OBSService>();
     }
 
     private static void ConfigureLogging(ILoggingBuilder builder)

--- a/SubathonManager.UI/Views/ObsAddSourceDialog.xaml
+++ b/SubathonManager.UI/Views/ObsAddSourceDialog.xaml
@@ -1,0 +1,54 @@
+﻿<ui:FluentWindow x:Class="SubathonManager.UI.Views.ObsAddSourceDialog"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+                 Title="Add to OBS"
+                 Width="400" Height="350"
+                 ResizeMode="NoResize"
+                 WindowStartupLocation="CenterOwner">
+    <Grid Margin="24 16 24 16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0">
+            <TextBlock Text="Add Browser Source to OBS"
+                       FontSize="15" FontWeight="SemiBold" Margin="0 0 0 16"/>
+
+            <TextBlock Text="Source Name" FontSize="11"
+                       Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0 0 0 3"/>
+            <ui:TextBox x:Name="SourceNameBox" Height="40" Margin="0 0 0 12" ClearButtonEnabled="False"/>
+
+            <TextBlock Text="Scene" FontSize="11"
+                       Foreground="{DynamicResource TextFillColorSecondaryBrush}" Margin="0 0 0 3"/>
+            <ComboBox x:Name="SceneComboBox"
+                      Height="40"
+                      IsEditable="True"
+                      IsTextSearchEnabled="True"
+                      StaysOpenOnEdit="True"
+                      Margin="0 0 0 12"/>
+
+            <TextBlock x:Name="SrgbOff"
+                       Text="Note: Some widgets may not look correct unless you set the browser source Blending Method to SRGB Off."
+                       TextWrapping="Wrap"
+                       Margin="0 0 0 12"/>
+
+            <CheckBox x:Name="FitToScreenCheckBox"
+                      Content="Fit to canvas?"
+                      IsChecked="False"
+                      Margin="0 0 0 0"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <ui:Button Content="Cancel"
+                       Appearance="Secondary"
+                       Width="90" Height="32"
+                       Margin="0 0 8 0"
+                       Click="Cancel_Click"/>
+            <ui:Button Content="Add Source"
+                       Width="110" Height="32"
+                       Click="AddSource_Click"/>
+        </StackPanel>
+    </Grid>
+</ui:FluentWindow>

--- a/SubathonManager.UI/Views/ObsAddSourceDialog.xaml.cs
+++ b/SubathonManager.UI/Views/ObsAddSourceDialog.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SubathonManager.Core;
+using SubathonManager.Core.Models;
+using SubathonManager.UI.Services;
+
+namespace SubathonManager.UI.Views;
+
+public partial class ObsAddSourceDialog
+{
+    private readonly Route _route;
+    private readonly string _url;
+    private readonly ILogger? _logger = AppServices.Provider.GetRequiredService<ILogger<ObsAddSourceDialog>>();
+
+    public ObsAddSourceDialog(Route route, string url, List<string> scenes, string currentScene)
+    {
+        InitializeComponent();
+        _route = route;
+        _url = url;
+
+        SourceNameBox.Text = $"[SMO] - {route.Name}";
+
+        var sorted = scenes.OrderBy(s => s).ToList();
+        SceneComboBox.ItemsSource = sorted;
+        SceneComboBox.SelectedItem = sorted.Contains(currentScene) ? currentScene : sorted.FirstOrDefault();
+    }
+
+    private async void AddSource_Click(object sender, RoutedEventArgs e)
+    {
+        string sourceName = SourceNameBox.Text.Trim();
+        string? selectedScene = SceneComboBox.SelectedItem as string ?? SceneComboBox.Text;
+
+        if (string.IsNullOrWhiteSpace(sourceName) || string.IsNullOrWhiteSpace(selectedScene))
+            return;
+
+        try
+        {
+            await ServiceManager.OBS.AddBrowserSource(
+                sourceName, _url, _route.Width, _route.Height, selectedScene,
+                FitToScreenCheckBox.IsChecked ?? false);
+            Close();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "[OBS] AddBrowserSource failed");
+        }
+    }
+
+    private void Cancel_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/SubathonManager.UI/Views/SettingsView.Obs.cs
+++ b/SubathonManager.UI/Views/SettingsView.Obs.cs
@@ -1,0 +1,67 @@
+﻿using System.Windows;
+using System.Windows.Input;
+using SubathonManager.Core.Enums;
+using SubathonManager.Core.Events;
+using SubathonManager.Core.Objects;
+using SubathonManager.UI.Services;
+
+namespace SubathonManager.UI.Views;
+
+public partial class SettingsView
+{
+    internal void InitOBSSettings()
+    {
+        var (host, port, pw) = ServiceManager.OBS.GetConfig();
+        SuppressUnsavedChanges(() =>
+        {
+            ObsHostBox.Text = host;
+            ObsPortBox.Text = port;
+            ObsPasswordBox.Password = pw;
+        });
+
+        IntegrationEvents.ConnectionUpdated += OnObsConnectionUpdated;
+        UpdateObsStatus(ServiceManager.OBS.Connected);
+    }
+
+    internal void UnloadOBSSettings()
+    {
+        IntegrationEvents.ConnectionUpdated -= OnObsConnectionUpdated;
+    }
+
+    private void OnObsConnectionUpdated(IntegrationConnection? connection)
+    {
+        if (connection is not { Source: SubathonEventSource.OBS }) return;
+        UpdateObsStatus(connection.Status);
+    }
+
+    private void UpdateObsStatus(bool connected)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            ObsStatusText.Text = connected ? "Connected" : "Disconnected";
+            ObsConnectBtn.Content = connected ? "Reconnect" : "Connect";
+        });
+    }
+
+    private void ObsConnect_Click(object sender, RoutedEventArgs e)
+    {
+        var host = ObsHostBox.Text.Trim();
+        var port = ObsPortBox.Text.Trim();
+        var password = ObsPasswordBox.Password.Trim();
+
+        if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(port)) return;
+
+        ServiceManager.OBS.SaveConfig(host, port, password, true);
+
+        if (ServiceManager.OBS.Connected)
+            ServiceManager.OBS.StopAsync();
+
+        ServiceManager.OBS.TryConnect();
+    }
+    
+    private void NumberOnly_PreviewTextInput(object sender, TextCompositionEventArgs e)
+    {
+        e.Handled = !int.TryParse(e.Text, out _);
+    }
+
+}

--- a/SubathonManager.UI/Views/SettingsView.xaml
+++ b/SubathonManager.UI/Views/SettingsView.xaml
@@ -179,27 +179,27 @@
                      <!-- OBS -->
                      <Expander Header="OBS WebSocket" IsExpanded="False">
                          <StackPanel Orientation="Vertical">
-                             <StackPanel Orientation="Horizontal" Margin="0 0 0 6">
-                                 <TextBlock Text="Host:" Width="80" VerticalAlignment="Center"/>
-                                 <ui:TextBox x:Name="ObsHostBox" Width="140" PlaceholderText="localhost" Margin="0 0 8 0"
-                                             local:SettingsProperties.ExcludeFromUnsaved="True"/>
-                                 <TextBlock Text="Port:" Width="40" VerticalAlignment="Center"/>
-                                 <ui:TextBox x:Name="ObsPortBox" Width="80" PlaceholderText="4455" Margin="0 0 8 0"
-                                             local:SettingsProperties.ExcludeFromUnsaved="True"
-                                             PreviewTextInput="NumberOnly_PreviewTextInput"/>
-                             </StackPanel>
-                             <StackPanel Orientation="Horizontal" Margin="0 0 0 6">
-                                 <TextBlock Text="Password:" Width="80" VerticalAlignment="Center"/>
-                                 <PasswordBox x:Name="ObsPasswordBox" Width="220" Height="30" Margin="0 0 8 0"/>
-                                 <TextBlock Text="(leave blank if none)" VerticalAlignment="Center" FontSize="11"
-                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
-                             </StackPanel>
-                             <StackPanel Orientation="Horizontal" Margin="0 4 0 0">
+                             <StackPanel Orientation="Horizontal" Margin="0 4 0 6">
                                  <ui:Button x:Name="ObsConnectBtn" Content="Connect" Width="100" Height="30"
                                             Margin="0 0 8 0" Click="ObsConnect_Click"
                                             local:SettingsProperties.ExcludeFromUnsaved="True"/>
                                  <TextBlock Text="Status:" VerticalAlignment="Center" Margin="0 0 4 0" FontSize="12"/>
                                  <TextBlock x:Name="ObsStatusText" VerticalAlignment="Center" FontSize="12" Text="Disconnected"/>
+                             </StackPanel>
+                             <StackPanel Orientation="Horizontal" Margin="0 0 0 6">
+                                 <TextBlock Text="Host:" Width="120" VerticalAlignment="Center"/>
+                                 <ui:TextBox x:Name="ObsHostBox" Width="140" PlaceholderText="localhost" Margin="0 0 32 0"
+                                             local:SettingsProperties.ExcludeFromUnsaved="True"/>
+                                 <TextBlock Text="Port:" Width="32" VerticalAlignment="Center"/>
+                                 <ui:TextBox x:Name="ObsPortBox" Width="80" PlaceholderText="4455" Margin="12 0 8 0"
+                                             local:SettingsProperties.ExcludeFromUnsaved="True" ClearButtonEnabled="False"
+                                             PreviewTextInput="NumberOnly_PreviewTextInput"/>
+                             </StackPanel>
+                             <StackPanel Orientation="Horizontal" Margin="0 0 0 6">
+                                 <TextBlock Text="Password:" Width="120" VerticalAlignment="Center"/>
+                                 <ui:PasswordBox x:Name="ObsPasswordBox" Width="220" Height="36" Margin="0 0 8 0" />
+                                 <TextBlock Text="(leave blank if none)" VerticalAlignment="Center" FontSize="11"
+                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
                              </StackPanel>
                          </StackPanel>
                      </Expander>

--- a/SubathonManager.UI/Views/SettingsView.xaml
+++ b/SubathonManager.UI/Views/SettingsView.xaml
@@ -176,6 +176,34 @@
                      <!-- Commands --> 
                      <views:CommandsSettings x:Name="CommandsSettingsControl" />
                     
+                     <!-- OBS -->
+                     <Expander Header="OBS WebSocket" IsExpanded="False">
+                         <StackPanel Orientation="Vertical">
+                             <StackPanel Orientation="Horizontal" Margin="0 0 0 6">
+                                 <TextBlock Text="Host:" Width="80" VerticalAlignment="Center"/>
+                                 <ui:TextBox x:Name="ObsHostBox" Width="140" PlaceholderText="localhost" Margin="0 0 8 0"
+                                             local:SettingsProperties.ExcludeFromUnsaved="True"/>
+                                 <TextBlock Text="Port:" Width="40" VerticalAlignment="Center"/>
+                                 <ui:TextBox x:Name="ObsPortBox" Width="80" PlaceholderText="4455" Margin="0 0 8 0"
+                                             local:SettingsProperties.ExcludeFromUnsaved="True"
+                                             PreviewTextInput="NumberOnly_PreviewTextInput"/>
+                             </StackPanel>
+                             <StackPanel Orientation="Horizontal" Margin="0 0 0 6">
+                                 <TextBlock Text="Password:" Width="80" VerticalAlignment="Center"/>
+                                 <PasswordBox x:Name="ObsPasswordBox" Width="220" Height="30" Margin="0 0 8 0"/>
+                                 <TextBlock Text="(leave blank if none)" VerticalAlignment="Center" FontSize="11"
+                                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"/>
+                             </StackPanel>
+                             <StackPanel Orientation="Horizontal" Margin="0 4 0 0">
+                                 <ui:Button x:Name="ObsConnectBtn" Content="Connect" Width="100" Height="30"
+                                            Margin="0 0 8 0" Click="ObsConnect_Click"
+                                            local:SettingsProperties.ExcludeFromUnsaved="True"/>
+                                 <TextBlock Text="Status:" VerticalAlignment="Center" Margin="0 0 4 0" FontSize="12"/>
+                                 <TextBlock x:Name="ObsStatusText" VerticalAlignment="Center" FontSize="12" Text="Disconnected"/>
+                             </StackPanel>
+                         </StackPanel>
+                     </Expander>
+                     
                      <!-- Webhook Logging --> 
                      <views:WebhookLogSettings x:Name="WebhookLogSettingsControl" />
                      

--- a/SubathonManager.UI/Views/SettingsView.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsView.xaml.cs
@@ -35,6 +35,7 @@ public partial class SettingsView : SettingsControl
             UpdateServerStatus(ServiceManager.Server?.Running ?? false);
             SubathonEvents.SubathonValueConfigUpdatedRemote += RefreshSubathonValues;
             SettingsEvents.SettingsUnsavedChanges += UpdateSaveButtonBorder;
+            InitOBSSettings();
             RegisterUnsavedChangeHandlers();
         };
 
@@ -53,6 +54,7 @@ public partial class SettingsView : SettingsControl
             //SubathonEvents.SubathonDataUpdate -= UpdateTimerValue;
             WebServerEvents.WebServerStatusChanged -= UpdateServerStatus;
             SubathonEvents.SubathonValueConfigUpdatedRemote -= RefreshSubathonValues;
+            UnloadOBSSettings();
         };
         
         Task.Run(CheckForUpdateOnBoot);

--- a/SubathonManager.UI/Views/SettingsViews/Extensions/StreamElementsSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/Extensions/StreamElementsSettings.xaml.cs
@@ -9,9 +9,12 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Data;
 using SubathonManager.Integration;
 using SubathonManager.UI.Services;
+// ReSharper disable NullableWarningSuppressionIsUsed
 
 namespace SubathonManager.UI.Views.SettingsViews.Extensions;
 
@@ -38,9 +41,8 @@ public partial class StreamElementsSettings : SettingsControl
     public override void Init(SettingsView host)
     {
         Host = host;
-
-        var config = AppServices.Provider.GetRequiredService<IConfig>();
-        SEJWTTokenBox.Text = config.Get("StreamElements", "JWT", string.Empty)!;
+        var secureStorage = AppServices.Provider.GetRequiredService<ISecureStorage>();
+        SEJWTTokenBox.Text = secureStorage.GetOrDefault(StorageKeys.StreamElementsJwt, string.Empty)!;
         UpdateStatus(Utils.GetConnection(SubathonEventSource.StreamElements, "Socket"));
     }
 

--- a/SubathonManager.UI/Views/SettingsViews/Extensions/StreamLabsSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/Extensions/StreamLabsSettings.xaml.cs
@@ -6,9 +6,10 @@ using Microsoft.Extensions.Logging;
 using SubathonManager.Core;
 using SubathonManager.Core.Enums;
 using SubathonManager.Core.Events;
-using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Data;
 using SubathonManager.Integration;
 using SubathonManager.UI.Services;
@@ -41,8 +42,8 @@ public partial class StreamLabsSettings : SettingsControl
     public override void Init(SettingsView host)
     {
         Host = host;
-        var config = AppServices.Provider.GetRequiredService<IConfig>();
-        SLTokenBox.Text = config.Get("StreamLabs", "SocketToken", string.Empty)!;
+        var secureStorage = AppServices.Provider.GetRequiredService<ISecureStorage>();
+        SLTokenBox.Text = secureStorage.GetOrDefault(StorageKeys.StreamLabsSocketToken, string.Empty)!;
         UpdateStatus(Utils.GetConnection(SubathonEventSource.StreamLabs, "Socket"));
     }
     

--- a/SubathonManager.UI/Views/SettingsViews/External/GoAffProSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/GoAffProSettings.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SubathonManager.Core;
@@ -9,6 +8,8 @@ using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Data;
 using SubathonManager.UI.Services;
 using SubathonManager.UI.Views.SettingsViews.External.GoAffPro;
@@ -188,6 +189,7 @@ public partial class GoAffProSettings : SettingsControl
         try
         {
             var config = AppServices.Provider.GetRequiredService<IConfig>();
+            var secureStorage = AppServices.Provider.GetRequiredService<ISecureStorage>();
             
             var msgBox = new Wpf.Ui.Controls.MessageBox
             {
@@ -209,7 +211,7 @@ public partial class GoAffProSettings : SettingsControl
             };
             var userBox = new Wpf.Ui.Controls.TextBox
             {
-                Text = config.GetFromEncoded(_configSection, "Email", string.Empty) ?? string.Empty,
+                Text = secureStorage.GetOrDefault(StorageKeys.GoAffProEmail, string.Empty) ?? string.Empty,
                 Width = 240,
                 Margin = new Thickness(2, 4, 0, 0)
             };
@@ -223,7 +225,7 @@ public partial class GoAffProSettings : SettingsControl
             };
             var pwBox = new Wpf.Ui.Controls.PasswordBox
             {
-                Password = config.GetFromEncoded(_configSection, "Password", string.Empty) ?? string.Empty,
+                Password = secureStorage.GetOrDefault(StorageKeys.GoAffProPassword, string.Empty) ?? string.Empty,
                 Width = 240,
                 Margin = new Thickness(2, 4, 0, 0)
             };
@@ -257,13 +259,13 @@ public partial class GoAffProSettings : SettingsControl
             await ServiceManager.GoAffPro.StopAsync();
 
             bool setData = false;
-            setData |= config.SetEncoded(_configSection, "Email", userBox.Text);
-            setData |= config.SetEncoded(_configSection, "Password", pwBox.Password);
+            setData |= secureStorage.Set(StorageKeys.GoAffProEmail, userBox.Text);
+            setData |= secureStorage.Set(StorageKeys.GoAffProPassword, pwBox.Password);
             if (setData) config.Save();
             
             
-            if (string.IsNullOrWhiteSpace(config.GetFromEncoded(_configSection, "Email", string.Empty))
-                || string.IsNullOrWhiteSpace(config.GetFromEncoded(_configSection, "Password", string.Empty)))
+            if (string.IsNullOrWhiteSpace(secureStorage.GetOrDefault(StorageKeys.GoAffProPassword, string.Empty))
+                || string.IsNullOrWhiteSpace(secureStorage.GetOrDefault(StorageKeys.GoAffProEmail, string.Empty)))
             {
                 return;
             }

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFi/KoFiWebhookSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFi/KoFiWebhookSettings.xaml.cs
@@ -8,7 +8,8 @@ using SubathonManager.Core.Enums;
 using SubathonManager.Core.Events;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
-using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Data;
 using SubathonManager.Integration;
 using Button = Wpf.Ui.Controls.Button;
@@ -39,6 +40,10 @@ public partial class KoFiWebhookSettings: DevTunnelSettingsControl
         {
             IntegrationEvents.ConnectionUpdated += UpdateStatus;
             RegisterUnsavedChangeHandlers();
+            SuppressUnsavedChanges(() =>
+            {
+                WireControl(KoFiWebhookTokenBox);
+            });
             RefreshFromStoredState();
         };
 
@@ -53,7 +58,8 @@ public partial class KoFiWebhookSettings: DevTunnelSettingsControl
         SuppressUnsavedChanges(() =>
         {
             var config = AppServices.Provider.GetRequiredService<IConfig>();
-            KoFiWebhookTokenBox.Text = config.GetFromEncoded(ConfigSection, "VerificationToken", string.Empty) ?? string.Empty;
+            var secureStorage = AppServices.Provider.GetRequiredService<ISecureStorage>();
+            KoFiWebhookTokenBox.Text = secureStorage.GetOrDefault(StorageKeys.KoFiVerificationToken, string.Empty) ?? string.Empty;
             KoFiWebhookForwardUrlsBox.Text = config.Get(ConfigSection, "ForwardUrls", string.Empty) ?? string.Empty;
         });
     }
@@ -62,7 +68,9 @@ public partial class KoFiWebhookSettings: DevTunnelSettingsControl
     {
         var config = AppServices.Provider.GetRequiredService<IConfig>();
         bool hasUpdated = false;
-        hasUpdated |= config.SetEncoded(ConfigSection, "VerificationToken", KoFiWebhookTokenBox.Password.Trim());
+        
+        var secureStorage = AppServices.Provider.GetRequiredService<ISecureStorage>();
+        hasUpdated |= secureStorage.Set(StorageKeys.KoFiVerificationToken, KoFiWebhookTokenBox.Password.Trim());
         hasUpdated |= config.Set(ConfigSection, "ForwardUrls", KoFiWebhookForwardUrlsBox.Text.Trim());
 
         if (hasUpdated)

--- a/SubathonManager.UI/Views/SettingsViews/External/KoFiCombinedSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/External/KoFiCombinedSettings.xaml.cs
@@ -8,6 +8,8 @@ using SubathonManager.Core.Enums;
 using SubathonManager.Core.Interfaces;
 using SubathonManager.Core.Models;
 using SubathonManager.Core.Objects;
+using SubathonManager.Core.Security;
+using SubathonManager.Core.Security.Interfaces;
 using SubathonManager.Data;
 using SubathonManager.Integration;
 using SubathonManager.UI.Views.SettingsViews.External.KoFi;
@@ -72,8 +74,8 @@ public partial class KoFiCombinedSettings : SettingsControl
         _webhook?.LoadValues(db);
 
         var config = AppServices.Provider.GetRequiredService<IConfig>();
-        bool hasToken = !string.IsNullOrWhiteSpace(
-            config.GetFromEncoded("KoFi", "VerificationToken", string.Empty));
+        var secureStorage = AppServices.Provider.GetRequiredService<ISecureStorage>();
+        bool hasToken = !string.IsNullOrWhiteSpace(secureStorage.GetOrDefault(StorageKeys.KoFiVerificationToken, string.Empty));
         WebhookRadio.IsChecked = hasToken;
         SocketRadio.IsChecked = !hasToken;
         SocketSlot.Visibility = hasToken ? Visibility.Collapsed : Visibility.Visible;

--- a/SubathonManager.UI/Views/SettingsViews/Streaming/TwitchSettings.xaml
+++ b/SubathonManager.UI/Views/SettingsViews/Streaming/TwitchSettings.xaml
@@ -30,6 +30,15 @@
             <TextBlock x:Name="EventSubStatusText" Text="Disconnected" VerticalAlignment="Center" FontSize="12" Margin="2 5 4 4" Width="75"/>
             
         </StackPanel>
+        <StackPanel Margin="0 4" Visibility="Collapsed" x:Name="DisconnectPanel">
+            <ui:Button x:Name="DisconnectTwitchBtn"
+                       Content="Disconnect"
+                       Width="120"
+                       Height="35"
+                       VerticalAlignment="Center"
+                       Margin="0,0,4,2"
+                       Click="DisconnectTwitchButton_Click"/>
+        </StackPanel>
         
         <StackPanel Margin="10,5,0,5">
             

--- a/SubathonManager.UI/Views/SettingsViews/Streaming/TwitchSettings.xaml.cs
+++ b/SubathonManager.UI/Views/SettingsViews/Streaming/TwitchSettings.xaml.cs
@@ -69,6 +69,8 @@ public partial class TwitchSettings : SettingsControl
                     if (!connection.Status) connectBtn = "Connect";
                     if (ConnectTwitchBtn.Content.ToString() != connectBtn) ConnectTwitchBtn.Content = connectBtn;
                     if (EventSubStatusText.Text != conStat) EventSubStatusText.Text = conStat;
+                    
+                    DisconnectPanel.Visibility = connection.Status ? Visibility.Visible : Visibility.Collapsed;
                     break;
                 }
                 case "Chat":
@@ -241,6 +243,25 @@ public partial class TwitchSettings : SettingsControl
                 break;
         }
         return (v, p, box, box2);
+    }
+
+    private async void DisconnectTwitchButton_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var cts = new CancellationTokenSource(5000);
+            ServiceManager.Twitch.RevokeTokenFile();
+            await Task.Delay(100, cts.Token);
+            await ServiceManager.Twitch.StopAsync(cts.Token);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error in Twitch disconnect");
+        }
+        finally
+        {
+            DisconnectPanel.Visibility = Visibility.Collapsed;
+        }
     }
 
     private async void ConnectTwitchButton_Click(object sender, RoutedEventArgs e)

--- a/presets/basic/event.html
+++ b/presets/basic/event.html
@@ -1,16 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:400
-Height:120
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/basic/#event
-applicableEvents.EventTypeList:TwitchSub,TwitchGiftSub,TwitchGiftSub,TwitchCheer,StreamElementsDonation,StreamLabsDonation,YouTubeMembership,YouTubeGiftMembership,YouTubeSuperChat,TwitchCharityDonation,ExternalDonation,ExternalSub,KoFiSub,KoFiDonation,BlerpBits,BlerpBeets,UwUMarketOrder,GamerSuppsOrder
-END_WIDGET_META
--->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-<link href='https://fonts.googleapis.com/css?family=Quantico' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@600;700&display=swap" rel="stylesheet">
+﻿<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
 
 <link rel="stylesheet" type="text/css" href="./event.styles.css" />
 

--- a/presets/basic/event.html.json
+++ b/presets/basic/event.html.json
@@ -29,6 +29,11 @@
         "GamerSuppsOrder"
       ],
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Quantico,Nunito,Baloo 2,Fredoka,Titan One"
     }
   }
 }

--- a/presets/basic/multiplier.html
+++ b/presets/basic/multiplier.html
@@ -1,15 +1,5 @@
-﻿<!--
-WIDGET_META
-Width:300
-Height:80
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/basic/#multiplier
-END_WIDGET_META
--->
+﻿
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-<link href='https://fonts.googleapis.com/css?family=Quantico' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@600;700&display=swap" rel="stylesheet">
 
 <link rel="stylesheet" type="text/css" href="./multiplier.styles.css" />
 

--- a/presets/basic/multiplier.html.json
+++ b/presets/basic/multiplier.html.json
@@ -3,5 +3,11 @@
   "Url": "https://docs.subathonmanager.app/latest/widgets/presets/themesets/basic/#multiplier",
   "Width": 300,
   "Height": 80,
-  "Vars": {}
+  "Vars": {
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Quantico,Nunito,Baloo 2,Fredoka,Titan One"
+    }
+  }
 }

--- a/presets/basic/next-goal.html
+++ b/presets/basic/next-goal.html
@@ -1,14 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:500
-Height:90
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/basic/#next-goal
-END_WIDGET_META
--->
-<link href='https://fonts.googleapis.com/css?family=Quantico' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@600;700&display=swap" rel="stylesheet">
+﻿
 <link rel="stylesheet" type="text/css" href="./next-goal.styles.css" />
 
 <div class="goal" id="goalContainer">

--- a/presets/basic/next-goal.html.json
+++ b/presets/basic/next-goal.html.json
@@ -3,5 +3,11 @@
   "Url": "https://docs.subathonmanager.app/latest/widgets/presets/themesets/basic/#next-goal",
   "Width": 500,
   "Height": 90,
-  "Vars": {}
+  "Vars": {
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Quantico,Nunito,Baloo 2,Fredoka,Titan One"
+    }
+  }
 }

--- a/presets/basic/points.html
+++ b/presets/basic/points.html
@@ -1,17 +1,5 @@
-﻿<!--
-WIDGET_META
-Width:230
-Height:70
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/basic/#points
-useForMoney.Boolean:False
-suffix.String:pts
-END_WIDGET_META
--->
+﻿
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-<link href='https://fonts.googleapis.com/css?family=Quantico' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" type="text/css" href="./points.styles.css" />
 
 <div class="points">

--- a/presets/basic/points.html.json
+++ b/presets/basic/points.html.json
@@ -17,6 +17,11 @@
       "Description": "Suffix for the value, such as pts",
       "Value": "pts",
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Quantico,Nunito,Baloo 2,Fredoka,Titan One"
     }
   }
 }

--- a/presets/basic/timer.html
+++ b/presets/basic/timer.html
@@ -1,21 +1,8 @@
-﻿<!--
-WIDGET_META
-Width:540
-Height:120
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/basic/#timer
-finishSound.SoundFile:./done.mp3
-playSoundOnFinish.Boolean:False
-soundVolume.Percent:100
-END_WIDGET_META
--->
+﻿
 <!--
 done.mp3 from: https://freesound.org/people/Kenneth_Cooney/sounds/609336/
 -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-<link href='https://fonts.googleapis.com/css?family=Quantico' rel='stylesheet'>
-<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@600;700&display=swap" rel="stylesheet">
 
 <link rel="stylesheet" type="text/css" href="./timer.styles.css"  />
 

--- a/presets/basic/timer.html.json
+++ b/presets/basic/timer.html.json
@@ -24,6 +24,11 @@
       "Description": "",
       "Value": 100,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Quantico,Nunito,Baloo 2,Fredoka,Titan One"
     }
   }
 }

--- a/presets/generic/compact/timer.html
+++ b/presets/generic/compact/timer.html
@@ -1,40 +1,7 @@
-﻿<!--
-WIDGET_META
-Width:500
-Height:160
-Url:https://docs.subathonmanager.app/latest/widgets/presets/single/compact-timer/
-showIcons.Boolean:False
-showSubs.Boolean:True
-subsLabel.String:subs
-subEvents.SubEventTypeList:TwitchSub,TwitchGiftSub,YouTubeMembership,YouTubeGiftMembership
-subCountOffset.Int:0
-showBitsTokens.Boolean:True
-tokensLabel.String:bits
-tokenEvents.TokenEventTypeList:TwitchCheer,BlerpBits,BlerpBeets
-tokensCountOffset.Int:0
-showTotalDonated.Boolean:True
-donatedLabel.String:NONE
-donatedOffset.Float:0
-showFollows.Boolean:True
-followsLabel.String:follows
-followEvents.FollowEventTypeList:TwitchFollow
-followCountOffset.Int:0
-showPoints.Boolean:True
-pointsLabel.String:pts
-pointsOffset.Int:0
-includeSimulated.Boolean:False
-finishSound.SoundFile:./bell.mp3
-playSoundOnFinish.Boolean:True
-soundVolume.Percent:50
-END_WIDGET_META
--->
-<!-- 
+﻿<!-- 
 bell.mp3 -> https://freesound.org/people/milesperhour425/sounds/424342/
 -->
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@700;800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="timer.css">
 
 <div class="timer-root" id="timer-root">

--- a/presets/generic/compact/timer.html.json
+++ b/presets/generic/compact/timer.html.json
@@ -175,6 +175,11 @@
       "Description": "",
       "Value": 50,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Quantico,Nunito,Baloo 2,Fredoka,Titan One"
     }
   }
 }

--- a/presets/generic/goal-bar.html
+++ b/presets/generic/goal-bar.html
@@ -1,20 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:600
-Height:80
-Author:WolfwithSword
-Url:https://docs.subathonmanager.app/latest/widgets/presets/single/goal-bar/
-goalType.StringSelect:Money,Points
-valuePrefix.String:NONE
-valueSuffix.String:NONE
-formatWithCommas.Boolean:False
-showDecimalsForMoney.Boolean:False
-overrideMax.Boolean:False
-maxGoalOverride.Int:10000
-overrideGoalText.Boolean:False
-goalTextOverride.String:NONE
-END_WIDGET_META
--->
+﻿
 <link rel="stylesheet" href="goal-bar.css">
 
 <div class="goal-root">

--- a/presets/generic/totals-goal-bar.html
+++ b/presets/generic/totals-goal-bar.html
@@ -1,21 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:600
-Height:80
-Author:WolfwithSword
-Url:https://docs.subathonmanager.app/latest/widgets/presets/single/total-goal-bar/
-eventGroup.EventSubTypeSelect:OrderLike
-eventType.EventTypeSelect:GamerSuppsOrder
-eventCountType.StringSelect:Count,Sum
-includeSimulated.Boolean:False
-valuePrefix.String:NONE
-valueSuffix.String:NONE
-formatWithCommas.Boolean:False
-goalMax.Int:10000
-goalOffset.Int:0
-goalText.String:Total
-END_WIDGET_META
--->
+﻿
 <link rel="stylesheet" href="goal-bar.css">
 
 <div class="goal-root">

--- a/presets/generic/totals/totals.html
+++ b/presets/generic/totals/totals.html
@@ -1,34 +1,5 @@
-<!--
-WIDGET_META
-Width:800
-Height:500
-Author:WolfwithSword
-Url:https://docs.subathonmanager.app/latest/widgets/presets/single/subathon-totals/
-orientation.StringSelect:vertical,horizontal
-includeSimulated.Boolean:False
-showSubs.Boolean:True
-subsHeader.String:Subs
-subEvents.SubEventTypeList:TwitchSub,TwitchGiftSub,YouTubeMembership,YouTubeGiftMembership
-subCountOffset.Int:0
-showBitsTokens.Boolean:True
-tokensHeader.String:Bits
-tokenEvents.TokenEventTypeList:TwitchCheer,BlerpBits,BlerpBeets
-tokensCountOffset.Int:0
-showFollows.Boolean:True
-followsHeader.String:Follows
-followEvents.FollowEventTypeList:TwitchFollow
-followCountOffset.Int:0
-showTotalDonated.Boolean:True
-donatedHeader.String:Total Donated
-donatedOffset.Float:0
-showOrders.Boolean:True
-ordersHeaderShowOrdersTag.Boolean:True
-orderEvents.OrderEventTypeList:UwUMarketOrder,GamerSuppsOrder,OrchidEightOrder
-ordersCountType.StringSelect:Orders,Items
-END_WIDGET_META
--->
-<link rel="stylesheet" href="totals.css">
 
+<link rel="stylesheet" href="totals.css">
 <div class="totals-root" id="totals-root"></div>
 
 <script>

--- a/presets/popups/alert/event-alert.html
+++ b/presets/popups/alert/event-alert.html
@@ -1,37 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:500
-Height:140
-Url:https://docs.subathonmanager.app/latest/widgets/presets/single/event-alerts/
-displaySeconds.Float:4
-applicableEvents.EventTypeList:TwitchSub,TwitchGiftSub,TwitchCheer,StreamElementsDonation,StreamLabsDonation,YouTubeMembership,YouTubeGiftMembership,YouTubeSuperChat,ExternalDonation,ExternalSub,KoFiSub,KoFiDonation,BlerpBits,BlerpBeets,UwUMarketOrder,GamerSuppsOrder,TwitchRaid,TwitchFollow,TwitchHypeTrain
-minDonationAmount.Float:5.00
-minTokensAmount.Int:100
-minRaidersAmount.Int:0
-animationDirection.StringSelect:top,bottom,left,right
-animationStyle.StringSelect:fade,slide
-exitAnimationDirection.StringSelect:top,bottom,left,right
-exitAnimationStyle.StringSelect:fade,slide
-followSound.SoundFile:NONE
-followVolume.Percent:50
-subSound.SoundFile:NONE
-subVolume.Percent:50
-giftSubSound.SoundFile:NONE
-giftSubVolume.Percent:50
-tokenSound.SoundFile:NONE
-tokenVolume.Percent:50
-raidSound.SoundFile:NONE
-raidVolume.Percent:50
-donationSound.SoundFile:NONE
-donationVolume.Percent:50
-trainSound.SoundFile:NONE
-trainVolume.Percent:50
-orderSound.SoundFile:NONE
-orderVolume.Percent:50
-END_WIDGET_META
--->
-
-<link rel="stylesheet" href="event-alert.css">
+﻿<link rel="stylesheet" href="event-alert.css">
 
 <div id="alertRoot">
     <div class="alert-card">

--- a/presets/popups/event-popups-v2.html
+++ b/presets/popups/event-popups-v2.html
@@ -1,22 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:480
-Height:200
-Author:WolfwithSword
-Url:https://docs.subathonmanager.app/latest/widgets/presets/single/event-popups/
-applicableEvents.EventSubTypeList:SubLike,GiftSubLike,DonationLike,TokenLike,OrderLike
-showSeconds.Boolean:True
-showPoints.Boolean:False
-showMoney.Boolean:False
-animation.StringSelect:float-up,float-down,popup
-groupGifts.Boolean:True
-END_WIDGET_META
--->
-<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/bright-orchid" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/milker" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/beachday" rel="stylesheet">
-<link rel="stylesheet" href="event-popups.css">
+﻿<link rel="stylesheet" href="event-popups.css">
 
 <div class="popup-root"></div>
 

--- a/presets/popups/event-popups-v2.html.json
+++ b/presets/popups/event-popups-v2.html.json
@@ -55,6 +55,16 @@
       "Description": "If true, 10 gifted will be a single popup. If false, it will be 10 separate popups",
       "Value": true,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Press Start 2P"
+    },
+    "CdnFonts" : {
+      "type": "CdnFont",
+      "description": "Additional cdn fonts to load to use in CSS Variables. Comma separated.",
+      "value": "bright-orchid,milker,beachday"
     }
   }
 }

--- a/presets/popups/event-popups.html
+++ b/presets/popups/event-popups.html
@@ -1,22 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:480
-Height:200
-Author:WolfwithSword
-Url:https://docs.subathonmanager.app/latest/widgets/presets/single/event-popups/
-applicableEvents.EventTypeList:TwitchSub,TwitchGiftSub,TwitchGiftSub,TwitchCheer,StreamElementsDonation,StreamLabsDonation,YouTubeMembership,YouTubeGiftMembership,YouTubeSuperChat,TwitchCharityDonation,ExternalDonation,ExternalSub,KoFiSub,KoFiDonation,BlerpBits,BlerpBeets,UwUMarketOrder,GamerSuppsOrder
-showSeconds.Boolean:True
-showPoints.Boolean:False
-showMoney.Boolean:False
-animation.StringSelect:float-up,float-down,popup
-groupGifts.Boolean:True
-END_WIDGET_META
--->
-<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/bright-orchid" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/milker" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/beachday" rel="stylesheet">
-<link rel="stylesheet" href="event-popups.css">
+﻿<link rel="stylesheet" href="event-popups.css">
 
 <div class="popup-root"></div>
 

--- a/presets/popups/event-popups.html.json
+++ b/presets/popups/event-popups.html.json
@@ -68,6 +68,16 @@
       "Description": "If true, 10 gifted will be a single popup. If false, it will be 10 separate popups",
       "Value": true,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Press Start 2P"
+    },
+    "CdnFonts" : {
+      "type": "CdnFont",
+      "description": "Additional cdn fonts to load to use in CSS Variables. Comma separated.",
+      "value": "bright-orchid,milker,beachday"
     }
   }
 }

--- a/presets/retro-pixel/event-value.html
+++ b/presets/retro-pixel/event-value.html
@@ -1,16 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:200
-Height:200
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/retro-pixel/#event-value
-eventType.EventTypeSelect:NONE
-optionalTier.String:NONE
-valueType.StringSelect:Seconds,Points
-showSuffix.Boolean:True
-alignment.StringSelect:Center,Left,Right
-END_WIDGET_META
--->
-<link href='https://fonts.googleapis.com/css?family=Press Start 2P' rel='stylesheet'>
+﻿
 <link rel="stylesheet" href="event-value.css">
 <div class="value-root">
     <div class="value-column">

--- a/presets/retro-pixel/event-value.html.json
+++ b/presets/retro-pixel/event-value.html.json
@@ -45,6 +45,11 @@
         "Left",
         "Right"
       ]
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Press Start 2P"
     }
   }
 }

--- a/presets/retro-pixel/event.html
+++ b/presets/retro-pixel/event.html
@@ -1,15 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:420
-Height:110
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/retro-pixel/#events
-minDisplaySeconds.Float:2
-applicableEvents.EventTypeList:TwitchSub,TwitchGiftSub,TwitchGiftSub,TwitchCheer,StreamElementsDonation,StreamLabsDonation,YouTubeMembership,YouTubeGiftMembership,YouTubeSuperChat,TwitchCharityDonation,ExternalDonation,ExternalSub,KoFiSub,KoFiDonation,BlerpBits,BlerpBeets,UwUMarketOrder,GamerSuppsOrder
-END_WIDGET_META
--->
-
-<link href="https://fonts.googleapis.com/css?family=Press Start 2P" rel="stylesheet">
-<link rel="stylesheet" href="event.css">
+﻿<link rel="stylesheet" href="event.css">
 
 <div class="event-root hidden" id="eventRoot">
     <div class="event-content">

--- a/presets/retro-pixel/event.html.json
+++ b/presets/retro-pixel/event.html.json
@@ -36,6 +36,11 @@
         "GamerSuppsOrder"
       ],
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Press Start 2P"
     }
   }
 }

--- a/presets/retro-pixel/goal-bar.html
+++ b/presets/retro-pixel/goal-bar.html
@@ -1,16 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:400
-Height:90
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/retro-pixel/#goals
-playSoundOnCompletedGoal.Boolean:True
-soundVolume.Percent:30
-completionSound.SoundFile:./complete.mp3
-END_WIDGET_META
--->
-
-<link href="https://fonts.googleapis.com/css?family=Press Start 2P" rel="stylesheet">
-<link rel="stylesheet" href="goal-bar.css">
+﻿<link rel="stylesheet" href="goal-bar.css">
 
 <div class="goal-root">
     <div class="goal-text" id="goalText">Waiting for goals…</div>

--- a/presets/retro-pixel/goal-bar.html.json
+++ b/presets/retro-pixel/goal-bar.html.json
@@ -24,6 +24,11 @@
       "Description": "",
       "Value": "./complete.mp3",
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Press Start 2P"
     }
   }
 }

--- a/presets/retro-pixel/goals-list.html
+++ b/presets/retro-pixel/goals-list.html
@@ -1,14 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:420
-Height:600
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/retro-pixel/#goals-list
-showLastCompleted.Boolean:True
-maxGoalsToShow.Int:3
-END_WIDGET_META
--->
-<link href="https://fonts.googleapis.com/css?family=Press Start 2P" rel="stylesheet">
-<link rel="stylesheet" type="text/css" href="./goals-list.css"  />
+﻿<link rel="stylesheet" type="text/css" href="./goals-list.css"  />
 <div class="container">
     <div class="goals-container" id="goalsContainer">
     </div>

--- a/presets/retro-pixel/goals-list.html.json
+++ b/presets/retro-pixel/goals-list.html.json
@@ -17,6 +17,11 @@
       "Description": "Max number of goals to show, including last completed if true",
       "Value": 3,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Press Start 2P"
     }
   }
 }

--- a/presets/retro-pixel/stats.html
+++ b/presets/retro-pixel/stats.html
@@ -1,19 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:300
-Height:320
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/retro-pixel/#stats
-iconMode.Boolean:False
-showPoints.Boolean:True
-showMoney.Boolean:True
-showTimeMultiplier.Boolean:True
-showHypeTrains.Boolean:True
-pointsName.String:Points
-alignment.StringSelect:Center,Left,Right
-END_WIDGET_META
--->
-<link href='https://fonts.googleapis.com/css?family=Press Start 2P' rel='stylesheet'>
-<link rel="stylesheet" href="stats.css">
+﻿<link rel="stylesheet" href="stats.css">
 <div class="stats-root">
     <div class="stats-column">
 

--- a/presets/retro-pixel/stats.html.json
+++ b/presets/retro-pixel/stats.html.json
@@ -56,6 +56,11 @@
         "Left",
         "Right"
       ]
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Press Start 2P"
     }
   }
 }

--- a/presets/retro-pixel/timer.html
+++ b/presets/retro-pixel/timer.html
@@ -1,21 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:440
-Height:180
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/retro-pixel/#timer
-showLeadingEmptyTime.Boolean:True
-minimumTimeUnitsShown.Int:2
-alignment.StringSelect:Center,Left,Right
-finishSound.SoundFile:./done.mp3
-playSoundOnFinish.Boolean:True
-soundVolume.Percent:80
-showDays.Boolean:True
-END_WIDGET_META
--->
-<!--
-done.mp3 from: https://freesound.org/people/Scrampunk/sounds/345297/
--->
-<link href='https://fonts.googleapis.com/css?family=Press Start 2P' rel='stylesheet'>
+﻿
 <link rel="stylesheet" href="timer.css">
 <div class="timer-root" data-state="running" id="timer-row">
     <div class="time-display">

--- a/presets/retro-pixel/timer.html.json
+++ b/presets/retro-pixel/timer.html.json
@@ -56,6 +56,11 @@
       "Description": "Show days as a separate box if true. If false, will add them into hours",
       "Value": true,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Press Start 2P"
     }
   }
 }

--- a/presets/simple-1/event.html
+++ b/presets/simple-1/event.html
@@ -1,18 +1,4 @@
-<!--
-WIDGET_META
-Width:240
-Height:100
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/simple-1/#event
-applicableEvents.EventTypeList:TwitchSub,TwitchGiftSub,TwitchGiftSub,TwitchCheer,StreamElementsDonation,StreamLabsDonation,YouTubeMembership,YouTubeGiftMembership,YouTubeSuperChat,TwitchCharityDonation,ExternalDonation,ExternalSub,KoFiSub,KoFiDonation,BlerpBits,BlerpBeets,UwUMarketOrder,GamerSuppsOrder
-END_WIDGET_META
--->
 <meta charset=utf-8>
-<link href="https://fonts.cdnfonts.com/css/bright-orchid" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/milker" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/beachday" rel="stylesheet">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Titan+One&display=swap" rel="stylesheet">
 <!--<script src=https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js></script>-->
 
 <link rel="stylesheet" type="text/css" href="./event.styles.css"  />

--- a/presets/simple-1/event.html.json
+++ b/presets/simple-1/event.html.json
@@ -29,6 +29,16 @@
         "GamerSuppsOrder"
       ],
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Titan One,Poppins"
+    },
+    "CdnFonts" : {
+      "type": "CdnFont",
+      "description": "Additional cdn fonts to load to use in CSS Variables. Comma separated.",
+      "value": "bright-orchid,milker,beachday"
     }
   }
 }

--- a/presets/simple-1/goals.html
+++ b/presets/simple-1/goals.html
@@ -1,18 +1,4 @@
-<!--
-WIDGET_META
-Width:400
-Height:600
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/simple-1/#goals
-showLastCompleted.Boolean:True
-END_WIDGET_META
--->
 <meta charset=utf-8>
-<link href="https://fonts.cdnfonts.com/css/bright-orchid" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/milker" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/beachday" rel="stylesheet">
-<!--<link rel="preconnect" href="https://fonts.googleapis.com">-->
-<!--<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>-->
-<!--<link href="https://fonts.googleapis.com/css2?family=Titan+One&display=swap" rel="stylesheet">-->
 
 <link rel="stylesheet" type="text/css" href="./goals.styles.css"  />
 <div class="container">

--- a/presets/simple-1/goals.html.json
+++ b/presets/simple-1/goals.html.json
@@ -4,17 +4,22 @@
   "Width": 400,
   "Height": 600,
   "Vars": {
-    "GoogleFonts" : {
-      "type": "GoogleFont",
-      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
-      "value": "Titan One"
-    },
     "showLastCompleted": {
       "Name": "showLastCompleted",
       "Type": "Boolean",
       "Description": "Show last completed goal but faded",
       "Value": true,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Titan One,Poppins"
+    },
+    "CdnFonts" : {
+      "type": "CdnFont",
+      "description": "Additional cdn fonts to load to use in CSS Variables. Comma separated.",
+      "value": "bright-orchid,milker,beachday"
     }
   }
 }

--- a/presets/simple-1/progress.html
+++ b/presets/simple-1/progress.html
@@ -1,20 +1,4 @@
-<!--
-WIDGET_META
-Width:350
-Height:120
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/simple-1/#progress
-pulseOnFull.Boolean:True
-showMarkers.Boolean:True
-useForMoney.Boolean:False
-END_WIDGET_META
--->
 <meta charset=utf-8>
-<link href="https://fonts.cdnfonts.com/css/bright-orchid" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/milker" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/beachday" rel="stylesheet">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Titan+One&display=swap" rel="stylesheet">
 <!--<script src=https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js></script>-->
 
 <link rel="stylesheet" type="text/css" href="./progress.styles.css"  />

--- a/presets/simple-1/progress.html.json
+++ b/presets/simple-1/progress.html.json
@@ -24,6 +24,16 @@
       "Description": "Track total donated for goal progress instead of points, if true",
       "Value": false,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Titan One,Poppins"
+    },
+    "CdnFonts" : {
+      "type": "CdnFont",
+      "description": "Additional cdn fonts to load to use in CSS Variables. Comma separated.",
+      "value": "bright-orchid,milker,beachday"
     }
   }
 }

--- a/presets/simple-1/timer.html
+++ b/presets/simple-1/timer.html
@@ -1,23 +1,7 @@
 <!--
-WIDGET_META
-Width:460
-Height:110
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/simple-1/#timer
-finishSound.SoundFile:./done.mp3
-playSoundOnFinish.Boolean:False
-soundVolume.Percent:50
-END_WIDGET_META
--->
-<!--
 done.mp3 from: https://freesound.org/people/lewisitoo/sounds/712851/
 -->
 <meta charset=utf-8>
-<link href="https://fonts.cdnfonts.com/css/bright-orchid" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/milker" rel="stylesheet">
-<link href="https://fonts.cdnfonts.com/css/beachday" rel="stylesheet">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Titan+One&display=swap" rel="stylesheet">
 <!--<script src=https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js></script>-->
 
 <link rel="stylesheet" type="text/css" href="./timer.styles.css"  />

--- a/presets/simple-1/timer.html.json
+++ b/presets/simple-1/timer.html.json
@@ -24,6 +24,16 @@
       "Description": "",
       "Value": 50,
       "Options": null
+    },
+    "GoogleFonts" : {
+      "type": "GoogleFont",
+      "description": "Additional google fonts to load to use in CSS Variables. Comma separated.",
+      "value": "Titan One,Poppins"
+    },
+    "CdnFonts" : {
+      "type": "CdnFont",
+      "description": "Additional cdn fonts to load to use in CSS Variables. Comma separated.",
+      "value": "bright-orchid,milker,beachday"
     }
   }
 }

--- a/presets/steampunk/event.html
+++ b/presets/steampunk/event.html
@@ -1,11 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:240
-Height:100
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/steampunk/#event
-applicableEvents.EventTypeList:TwitchSub,TwitchGiftSub,TwitchGiftSub,TwitchCheer,StreamElementsDonation,StreamLabsDonation,YouTubeMembership,YouTubeGiftMembership,YouTubeSuperChat,TwitchCharityDonation,ExternalDonation,ExternalSub,KoFiSub,KoFiDonation,BlerpBits,BlerpBeets,UwUMarketOrder,GamerSuppsOrder
-END_WIDGET_META
--->
+﻿
 <meta charset=utf-8>
 <link rel="stylesheet" type="text/css" href="./event.css"  />
 <div id="event-content" class="event-content"></div>

--- a/presets/steampunk/goals.html
+++ b/presets/steampunk/goals.html
@@ -1,12 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:400
-Height:600
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/steampunk/#goals
-showLastCompleted.Boolean:True
-maxGoalsToShow.Int:3
-END_WIDGET_META
--->
+﻿
 <link rel="stylesheet" type="text/css" href="./goals.css"  />
 <div class="container">
     <div class="goals-container" id="goalsContainer">

--- a/presets/steampunk/multiplier.html
+++ b/presets/steampunk/multiplier.html
@@ -1,10 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:186
-Height:160
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/steampunk/#multiplier
-END_WIDGET_META
--->
+﻿
 <link rel="stylesheet" href="multiplier.css">
 
 <div class="container">

--- a/presets/steampunk/points.html
+++ b/presets/steampunk/points.html
@@ -1,11 +1,4 @@
-﻿<!--
-WIDGET_META
-Width:520
-Height:170
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/steampunk/#points
-useForMoney.Boolean:False
-END_WIDGET_META
--->
+﻿
 <link rel="stylesheet" href="nixie-tube.css">
 
 <div class="nixie-container" id="pointsContainer">

--- a/presets/steampunk/timer.html
+++ b/presets/steampunk/timer.html
@@ -1,14 +1,4 @@
 ﻿<!--
-WIDGET_META
-Width:950
-Height:180
-Url:https://docs.subathonmanager.app/latest/widgets/presets/themesets/steampunk/#timer
-finishSound.SoundFile:./done.mp3
-playSoundOnFinish.Boolean:False
-soundVolume.Percent:50
-END_WIDGET_META
--->
-<!--
 done.mp3 from: https://freesound.org/people/aj_heels/sounds/634089/
 -->
 <link rel="stylesheet" href="nixie-tube.css">


### PR DESCRIPTION
- Added subathon cap/enddate support
  - This will be configurable on main page anytime. Will override seconds remaining at source without modifying underlying data if the time matchup from now to enddate is less than time remaining.
- Added stats panel, on hover of timer on home page, shows time elapsed, time accumulated (not in reverse mode), and number of real events
- Added lightweight OBS integration. Allows for auto importing overlays as browser sources.
- Adds SecureStore implementation for encrypting auth credentials and tokens

Note: If you have ever used the SET TIME feature, the time accumulated will be reset to [time elapsed + time set to]

closes #240 
closes #241 
closes #236
closes #244