### PR TITLE
OBS Canvas Sync

### DIFF
--- a/SubathonManager.Integration/OBSService.cs
+++ b/SubathonManager.Integration/OBSService.cs
@@ -115,19 +115,23 @@ public class OBSService : IAppService {
         if (v.AvailableRequests.Contains("GetCanvasList")) {
             try {
                 var response = _obs.SendRequest("GetCanvasList");
+                var count = 1;
                 if (response != null && response.TryGetValue("canvases", out JToken? _canvases)) {
                     foreach (var canvas in _canvases) {
-                        string canvasName = (string)canvas["canvasName"];
+                        
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+                        string canvasName = (string)canvas["canvasName"] ?? $"Canvas {count}";
+
                         var videoSettings = canvas["canvasVideoSettings"];
                         var flags = canvas["canvasFlags"];
-                        if ((bool)flags["MAIN"]) {
+                        if ((bool)(flags?["MAIN"] ?? false)) {
                             canvases.Remove("Default");
                         }
                         canvases.Add(canvasName, new () {
-                            {"Width", (int)videoSettings["baseWidth"]},
-                            {"Height", (int)videoSettings["baseHeight"]}
+                            {"Width", (int)(videoSettings?["baseWidth"] ?? 1920)},
+                            {"Height", (int)(videoSettings?["baseHeight"] ?? 1080)}
                         });
-
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
                     }
                 }
             }

--- a/SubathonManager.Integration/OBSService.cs
+++ b/SubathonManager.Integration/OBSService.cs
@@ -97,6 +97,55 @@ public class OBSService : IAppService {
 
     public event Action? BrowserSourcesChanged;
 
+    public Dictionary<string, Dictionary<string, int>> GetCanvases() {
+        var canvases = new Dictionary<string, Dictionary<string, int>>();
+        if (!_obs.IsConnected) {
+            return canvases;
+        }
+        
+        var currentCanvas = _obs.GetVideoSettings();
+        
+        canvases.Add("Default", new () {
+            {"Width", currentCanvas.BaseWidth},
+            {"Height", currentCanvas.BaseHeight}
+        });
+        
+        var v = _obs.GetVersion();
+        
+        if (v.AvailableRequests.Contains("GetCanvasList")) {
+            try {
+                var response = _obs.SendRequest("GetCanvasList");
+                if (response != null && response.TryGetValue("canvases", out JToken? _canvases)) {
+                    foreach (var canvas in _canvases) {
+                        string canvasName = (string)canvas["canvasName"];
+                        var videoSettings = canvas["canvasVideoSettings"];
+                        var flags = canvas["canvasFlags"];
+                        if ((bool)flags["MAIN"]) {
+                            canvases.Remove("Default");
+                        }
+                        canvases.Add(canvasName, new () {
+                            {"Width", (int)videoSettings["baseWidth"]},
+                            {"Height", (int)videoSettings["baseHeight"]}
+                        });
+
+                    }
+                }
+            }
+            catch (Exception ex) {
+                _logger?.LogWarning(ex, "[OBSService] GetCanvasList request failed");
+            }
+        }
+
+        if (canvases.Count == 0) {
+            canvases.Add("Default", new () {
+                {"Width", currentCanvas.BaseWidth},
+                {"Height", currentCanvas.BaseHeight}
+            });
+        }
+
+        return canvases;
+    }
+
     public List<string> GetScenes() {
         return _obs.GetSceneList().Scenes
             .Select(s => s.Name)

--- a/SubathonManager.Services/EventService.cs
+++ b/SubathonManager.Services/EventService.cs
@@ -186,6 +186,7 @@ public class EventService : IDisposable, IAppService {
             ///////////////////////////////////////////////////////////////
             ev.PointsValue = (int)Math.Floor(subathonValue!.Points);
             if (double.TryParse(ev.Value, out double parsedValue)
+                && ev.Currency != "viewers"
                 && ev.Currency != "sub" && ev.Currency != "member" && ev.Currency != "order" // allow items from orders
                 && !_currencyService.IsValidCurrency(ev.Currency)
                 && !string.IsNullOrEmpty(ev.Value.Trim())) {
@@ -213,6 +214,11 @@ public class EventService : IDisposable, IAppService {
             }
             else {
                 ev.SecondsValue = subathonValue.Seconds;
+            }
+
+            if (ev.EventType.IsRaid()) {
+                // All raid types are always points per raid never viewer
+                ev.PointsValue = (int)Math.Floor(subathonValue!.Points);
             }
 
             if (ev.EventType.IsCurrencyDonation() && (string.IsNullOrEmpty(ev.Currency) ||

--- a/SubathonManager.UI/EditRouteWindow.Handlers.cs
+++ b/SubathonManager.UI/EditRouteWindow.Handlers.cs
@@ -21,6 +21,7 @@ using SubathonManager.Core.Models;
 using SubathonManager.Data;
 using SubathonManager.Data.Widgets;
 using SubathonManager.UI.Controls;
+using SubathonManager.UI.Services;
 using SubathonManager.UI.UiUtils;
 using SubathonManager.UI.Validation;
 using SubathonManager.UI.Views;
@@ -29,6 +30,8 @@ using SubathonManager.UI.Views;
 namespace SubathonManager.UI;
 
 public partial class EditRouteWindow {
+    private MenuFlyout? _statusFlyout;
+    
     #region GeneralHandlers
 
     private void WidgetDirtyBorder_Loaded(object? sender, RoutedEventArgs e) {
@@ -143,6 +146,38 @@ public partial class EditRouteWindow {
         }
         catch (Exception ex) {
             _logger?.LogError(ex, "Failed to copy overlay URL");
+        }
+    }
+    
+    private void ShowObsCanvasSelection_Click(object? sender, RoutedEventArgs e) {
+        var flyout = new MenuFlyout { Placement = PlacementMode.Bottom };
+        
+        FillObsCanvases(flyout.Items);///////
+        flyout.Closed += (_, _) => {
+            if (ReferenceEquals(_statusFlyout, flyout)) _statusFlyout = null;
+        };
+        _statusFlyout = flyout;
+        flyout.ShowAt(OBSCanvasSyncBtn);
+    }
+
+    private void FillObsCanvases(ItemCollection items) {
+        items.Clear();
+        var canvases = ServiceManager.OBS.GetCanvases();
+        if (canvases.Count == 0) return;
+        
+        foreach (var canvasData in canvases) {
+            var width = canvasData.Value["Width"];
+            var height = canvasData.Value["Height"];
+            var name = $"{canvasData.Key} (WxH {width}x{height})";
+            var groupItem = new MenuItem {
+                Header = name
+            };
+            groupItem.Click += async (_, _) => {
+                RouteHeightBox.Text = $"{height}";
+                RouteWidthBox.Text = $"{width}";
+                await SaveCurrentRoute();
+            };
+            items.Add(groupItem);
         }
     }
 
@@ -900,6 +935,11 @@ public partial class EditRouteWindow {
     }
 
     private async void SaveRouteButton_Click(object? sender, RoutedEventArgs e) {
+        if (_route == null) return;
+        await SaveCurrentRoute();
+    }
+
+    private async Task SaveCurrentRoute() {
         if (_route == null) return;
         try {
             await SaveAllPendingWidgetChangesAsync();

--- a/SubathonManager.UI/EditRouteWindow.axaml
+++ b/SubathonManager.UI/EditRouteWindow.axaml
@@ -356,18 +356,29 @@
                 <TextBlock Text="Name" FontSize="12" />
                 <TextBox x:Name="RouteNameBox" Margin="0,4,0,8" PlaceholderText="Overlay Name..."
                          VerticalContentAlignment="Center" />
-                <StackPanel Orientation="Horizontal">
-                    <StackPanel Margin="0,2,2,2">
-                        <TextBlock Text="Width" FontSize="12" />
-                        <TextBox x:Name="RouteWidthBox" Width="120" v:NumericInputBehaviour.Mode="Integer"
-                                 PlaceholderText="1920" VerticalContentAlignment="Center" />
+                
+                <Grid>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                        <StackPanel Margin="0,2,2,2">
+                            <TextBlock Text="Width" FontSize="12" />
+                            <TextBox x:Name="RouteWidthBox" Width="100" v:NumericInputBehaviour.Mode="Integer"
+                                     PlaceholderText="1920" VerticalContentAlignment="Center" />
+                        </StackPanel>
+                        <StackPanel Margin="2,2,0,2">
+                            <TextBlock Text="Height" FontSize="12" />
+                            <TextBox x:Name="RouteHeightBox" Width="100" v:NumericInputBehaviour.Mode="Integer"
+                                     PlaceholderText="1080" VerticalContentAlignment="Center" />
+                        </StackPanel>
                     </StackPanel>
-                    <StackPanel Margin="2,2,0,2">
-                        <TextBlock Text="Height" FontSize="12" />
-                        <TextBox x:Name="RouteHeightBox" Width="120" v:NumericInputBehaviour.Mode="Integer"
-                                 PlaceholderText="1080" VerticalContentAlignment="Center" />
-                    </StackPanel>
-                </StackPanel>
+                    
+                    <Button x:Name="OBSCanvasSyncBtn" HorizontalAlignment="Right" Margin="0 18 2 0"
+                            ToolTip.Tip="Sync Overlay Dimensions to an OBS Canvas" 
+                            Click="ShowObsCanvasSelection_Click"
+                            IsVisible="{Binding ObsConnected, RelativeSource={RelativeSource AncestorType=Window}}"
+                            Width="128" Height="32" VerticalAlignment="Center" Cursor="Hand">
+                        Sync to Canvas
+                    </Button>
+                </Grid>
 
                 <Grid Margin="0,10,0,0">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">


### PR DESCRIPTION
Add option to sync the current overlay dimensions to a selection from OBS's (if connected) canvases

<img width="422" height="135" alt="image" src="https://github.com/user-attachments/assets/0c850459-5b74-43de-89d1-19f2a60d29bf" />

Also fixes `TwitchRaid` points per raid being inappropriately set to points per viewer.

closes #325 